### PR TITLE
feat: implementación de CRUD de estados del informe preliminar

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,6 +12,7 @@ import { AuditorModule } from './auditoria-auditor/auditor.module';
 import { EstadoAuditoriaModule } from './auditoria-estado/auditoria-estado.module';
 import { InformeModule } from './informe/informe.module';
 import { TemaModule } from './tema/tema.module';
+import { InformeEstadoModule } from './informe-estado/informe-estado.module';
 
 @Module({
   imports: [
@@ -36,6 +37,7 @@ import { TemaModule } from './tema/tema.module';
     AuditorModule,
     InformeModule,
     TemaModule,
+    InformeEstadoModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/informe-estado/dto/informe-estado.dto.ts
+++ b/src/informe-estado/dto/informe-estado.dto.ts
@@ -1,0 +1,27 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class InformeEstadoDto {
+  @ApiProperty()
+  readonly informe_id: string;
+
+  @ApiProperty()
+  readonly usuario_id: number;
+
+  @ApiProperty()
+  readonly usuario_rol: string;
+
+  @ApiProperty()
+  readonly observacion: string;
+
+  @ApiProperty()
+  readonly actual: boolean;
+
+  @ApiProperty()
+  readonly estado_id: number;
+
+  @ApiProperty()
+  readonly fecha_ejecucion_estado: Date;
+
+  @ApiProperty()
+  activo: boolean;
+}

--- a/src/informe-estado/informe-estado.controller.spec.ts
+++ b/src/informe-estado/informe-estado.controller.spec.ts
@@ -1,0 +1,317 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { InformeEstadoController } from './informe-estado.controller';
+import { InformeEstadoDto } from './dto/informe-estado.dto';
+import { InformeEstadoService } from './informe-estado.service';
+import { HttpStatus } from '@nestjs/common';
+import { FilterDto } from '../filters/filters.dto';
+
+const mockInformeEstadoDTO: InformeEstadoDto = {
+  informe_id: '507f1f77bcf86cd799439011',
+  usuario_id: 123,
+  usuario_rol: 'Auditor',
+  observacion: 'Estado inicial del informe',
+  estado_id: 1,
+  fecha_ejecucion_estado: new Date(),
+  activo: true,
+  actual: true,
+};
+
+const mockInformeEstado = {
+  ...mockInformeEstadoDTO,
+  _id: '507f1f77bcf86cd799439012',
+};
+
+describe('InformeEstadoController', () => {
+  let controller: InformeEstadoController;
+  let service: InformeEstadoService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [InformeEstadoController],
+      providers: [
+        {
+          provide: InformeEstadoService,
+          useValue: {
+            post: jest.fn(),
+            getAll: jest.fn(),
+            getById: jest.fn(),
+            put: jest.fn(),
+            delete: jest.fn(),
+            count: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<InformeEstadoController>(InformeEstadoController);
+    service = module.get<InformeEstadoService>(InformeEstadoService);
+  });
+
+  it('Debería estar definido', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('post', () => {
+    it('Debería retornar Created con datos válidos', async () => {
+      jest.spyOn(service, 'post').mockResolvedValue(mockInformeEstado as any);
+
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      await controller.post(res as any, mockInformeEstadoDTO);
+
+      expect(service.post).toHaveBeenCalledWith(mockInformeEstadoDTO);
+      expect(res.status).toHaveBeenCalledWith(HttpStatus.CREATED);
+      expect(res.json).toHaveBeenCalledWith({
+        Success: true,
+        Status: HttpStatus.CREATED,
+        Message: 'Registro Exitoso',
+        Data: mockInformeEstado,
+      });
+    });
+
+    it('Debería retornar BadRequest con error', async () => {
+      const mockError = new Error(
+        'InformeEstado validation failed: activo: Cast to Boolean failed',
+      );
+
+      jest.spyOn(service, 'post').mockRejectedValue(mockError);
+
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      await controller.post(res as any, mockInformeEstadoDTO);
+
+      expect(service.post).toHaveBeenCalledWith(mockInformeEstadoDTO);
+      expect(res.status).toHaveBeenCalledWith(HttpStatus.BAD_REQUEST);
+      expect(res.json).toHaveBeenCalledWith({
+        Success: false,
+        Status: HttpStatus.BAD_REQUEST,
+        Message:
+          'Error servicio Post: la solicitud contiene un tipo de dato incorrecto o un parametro invalido',
+        Data: mockError.message,
+      });
+    });
+  });
+
+  describe('getAll', () => {
+    const mockFilterDto: FilterDto = {
+      query: '',
+      fields: '',
+      sortby: '',
+      order: '',
+      limit: '',
+      offset: '',
+      populate: '',
+    };
+
+    beforeEach(() => {
+      jest.spyOn(service, 'count').mockResolvedValue(2);
+    });
+
+    it('Debería retornar OK con datos válidos', async () => {
+      const mockEstados = [
+        {
+          ...mockInformeEstado,
+          _id: '1',
+          usuario_id: 123,
+        },
+        {
+          ...mockInformeEstado,
+          _id: '2',
+          usuario_id: 456,
+        },
+      ];
+
+      jest.spyOn(service, 'getAll').mockResolvedValue(mockEstados as any);
+
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      await controller.getAll(res as any, mockFilterDto);
+
+      expect(service.getAll).toHaveBeenCalledWith(mockFilterDto);
+      expect(service.count).toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(HttpStatus.OK);
+      expect(res.json).toHaveBeenCalledWith({
+        Success: true,
+        Status: HttpStatus.OK,
+        Message: 'Peticion Exitosa',
+        Data: mockEstados,
+        MetaData: { Count: 2 },
+      });
+    });
+
+    it('Debería retornar NotFound con error', async () => {
+      const mockError = new Error('No records found');
+
+      jest.spyOn(service, 'getAll').mockRejectedValue(mockError);
+
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      await controller.getAll(res as any, mockFilterDto);
+
+      expect(service.getAll).toHaveBeenCalledWith(mockFilterDto);
+      expect(res.status).toHaveBeenCalledWith(HttpStatus.NOT_FOUND);
+      expect(res.json).toHaveBeenCalledWith({
+        Success: false,
+        Status: HttpStatus.NOT_FOUND,
+        Message:
+          'Error en servicio GetAll: la peticion contiene un parametro incorrecto o no existe un registro',
+        Data: mockError.message,
+      });
+    });
+  });
+
+  describe('getById', () => {
+    it('Debería retornar OK con id válido', async () => {
+      jest.spyOn(service, 'getById').mockResolvedValue(mockInformeEstado as any);
+
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      await controller.getById(res as any, mockInformeEstado._id);
+
+      expect(service.getById).toHaveBeenCalledWith(mockInformeEstado._id);
+      expect(res.status).toHaveBeenCalledWith(HttpStatus.OK);
+      expect(res.json).toHaveBeenCalledWith({
+        Success: true,
+        Status: HttpStatus.OK,
+        Message: 'Peticion Exitosa',
+        Data: mockInformeEstado,
+      });
+    });
+
+    it('Debería retornar NotFound con id inválido', async () => {
+      jest
+        .spyOn(service, 'getById')
+        .mockRejectedValue(new Error(`${mockInformeEstado._id} no existe`));
+
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      await controller.getById(res as any, mockInformeEstado._id);
+
+      expect(service.getById).toHaveBeenCalledWith(mockInformeEstado._id);
+      expect(res.status).toHaveBeenCalledWith(HttpStatus.NOT_FOUND);
+      expect(res.json).toHaveBeenCalledWith({
+        Success: false,
+        Status: HttpStatus.NOT_FOUND,
+        Message:
+          'Error en servicio GetOne: la peticion contiene un parametro incorrecto o no existe un registro',
+        Data: `${mockInformeEstado._id} no existe`,
+      });
+    });
+  });
+
+  describe('put', () => {
+    it('Debería retornar OK con datos válidos', async () => {
+      jest.spyOn(service, 'put').mockResolvedValue(mockInformeEstado as any);
+
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      await controller.put(res as any, mockInformeEstado._id, mockInformeEstadoDTO);
+
+      expect(service.put).toHaveBeenCalledWith(
+        mockInformeEstado._id,
+        mockInformeEstadoDTO,
+      );
+      expect(res.status).toHaveBeenCalledWith(HttpStatus.OK);
+      expect(res.json).toHaveBeenCalledWith({
+        Success: true,
+        Status: HttpStatus.OK,
+        Message: 'Actualizacion Exitosa',
+        Data: mockInformeEstado,
+      });
+    });
+
+    it('Debería retornar BadRequest con error', async () => {
+      const mockError = new Error(`${mockInformeEstado._id} no existe`);
+
+      jest.spyOn(service, 'put').mockRejectedValue(mockError);
+
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      await controller.put(res as any, mockInformeEstado._id, mockInformeEstadoDTO);
+
+      expect(service.put).toHaveBeenCalledWith(
+        mockInformeEstado._id,
+        mockInformeEstadoDTO,
+      );
+      expect(res.status).toHaveBeenCalledWith(HttpStatus.BAD_REQUEST);
+      expect(res.json).toHaveBeenCalledWith({
+        Success: false,
+        Status: HttpStatus.BAD_REQUEST,
+        Message:
+          'Error en servicio Put: la peticion contiene un tipo de dato incorrecto o un parametro invalido',
+        Data: mockError.message,
+      });
+    });
+  });
+
+  describe('delete', () => {
+    it('Debería retornar OK con id válido', async () => {
+      jest.spyOn(service, 'delete').mockResolvedValue(undefined);
+
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      await controller.delete(res as any, mockInformeEstado._id);
+
+      expect(service.delete).toHaveBeenCalledWith(mockInformeEstado._id);
+      expect(res.status).toHaveBeenCalledWith(HttpStatus.OK);
+      expect(res.json).toHaveBeenCalledWith({
+        Success: true,
+        Status: HttpStatus.OK,
+        Message: 'Eliminacion Exitosa',
+        Data: {
+          _id: mockInformeEstado._id,
+        },
+      });
+    });
+
+    it('Debería retornar NotFound con error', async () => {
+      const mockError = new Error('Record not found');
+
+      jest.spyOn(service, 'delete').mockRejectedValue(mockError);
+
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      await controller.delete(res as any, mockInformeEstado._id);
+
+      expect(service.delete).toHaveBeenCalledWith(mockInformeEstado._id);
+      expect(res.status).toHaveBeenCalledWith(HttpStatus.NOT_FOUND);
+      expect(res.json).toHaveBeenCalledWith({
+        Success: false,
+        Status: HttpStatus.NOT_FOUND,
+        Message:
+          'Error en el servicio Delete: la peticion contiene parametros incorrectos',
+        Data: mockError.message,
+      });
+    });
+  });
+});

--- a/src/informe-estado/informe-estado.controller.ts
+++ b/src/informe-estado/informe-estado.controller.ts
@@ -1,0 +1,186 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpStatus,
+  Param,
+  Post,
+  Put,
+  Query,
+  Res,
+} from '@nestjs/common';
+import { FilterDto } from '../filters/filters.dto';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiBody,
+} from '@nestjs/swagger';
+import { InformeEstadoService } from './informe-estado.service';
+import { InformeEstadoDto } from './dto/informe-estado.dto';
+
+@ApiTags('informe-estado')
+@Controller('informe-estado')
+export class InformeEstadoController {
+  constructor(private informeEstadoService: InformeEstadoService) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Crear un nuevo estado de informe' })
+  @ApiBody({ type: InformeEstadoDto })
+  @ApiResponse({
+    status: 201,
+    description: 'El estado de informe ha sido creado exitosamente.',
+    type: InformeEstadoDto,
+  })
+  @ApiResponse({ status: 400, description: 'Solicitud incorrecta.' })
+  async post(@Res() res, @Body() informeEstadoDto: InformeEstadoDto) {
+    try {
+      const estadoInforme =
+        await this.informeEstadoService.post(informeEstadoDto);
+      res.status(HttpStatus.CREATED).json({
+        Success: true,
+        Status: HttpStatus.CREATED,
+        Message: 'Registro Exitoso',
+        Data: estadoInforme,
+      });
+    } catch (error) {
+      res.status(HttpStatus.BAD_REQUEST).json({
+        Success: false,
+        Status: HttpStatus.BAD_REQUEST,
+        Message:
+          'Error servicio Post: la solicitud contiene un tipo de dato incorrecto o un parametro invalido',
+        Data: error.message,
+      });
+    }
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'Obtener todos los estados de informe' })
+  @ApiResponse({
+    status: 200,
+    description: 'Devuelve todos los estados de informe.',
+    type: [InformeEstadoDto],
+  })
+  async getAll(@Res() res, @Query() filterDto: FilterDto) {
+    try {
+      const estadoInforme =
+        await this.informeEstadoService.getAll(filterDto);
+      const counts = await this.informeEstadoService.count(filterDto);
+
+      res.status(HttpStatus.OK).json({
+        Success: true,
+        Status: HttpStatus.OK,
+        Message: 'Peticion Exitosa',
+        Data: estadoInforme,
+        MetaData: { Count: counts },
+      });
+    } catch (error) {
+      res.status(HttpStatus.NOT_FOUND).json({
+        Success: false,
+        Status: HttpStatus.NOT_FOUND,
+        Message:
+          'Error en servicio GetAll: la peticion contiene un parametro incorrecto o no existe un registro',
+        Data: error.message,
+      });
+    }
+  }
+
+  @Get('/:id')
+  @ApiOperation({ summary: 'Obtener un estado de informe por Id' })
+  @ApiParam({ name: 'id', type: 'string' })
+  @ApiResponse({
+    status: 200,
+    description: 'Devuelve el estado de informe.',
+    type: InformeEstadoDto,
+  })
+  @ApiResponse({ status: 404, description: 'Estado no encontrado.' })
+  async getById(@Res() res, @Param('id') id: string) {
+    try {
+      const estadoInforme = await this.informeEstadoService.getById(id);
+      res.status(HttpStatus.OK).json({
+        Success: true,
+        Status: HttpStatus.OK,
+        Message: 'Peticion Exitosa',
+        Data: estadoInforme,
+      });
+    } catch (error) {
+      res.status(HttpStatus.NOT_FOUND).json({
+        Success: false,
+        Status: HttpStatus.NOT_FOUND,
+        Message:
+          'Error en servicio GetOne: la peticion contiene un parametro incorrecto o no existe un registro',
+        Data: error.message,
+      });
+    }
+  }
+
+  @Put('/:id')
+  @ApiOperation({ summary: 'Actualizar un estado de informe' })
+  @ApiParam({ name: 'id', type: 'string' })
+  @ApiBody({ type: InformeEstadoDto })
+  @ApiResponse({
+    status: 200,
+    description: 'El estado de informe ha sido actualizado exitosamente.',
+    type: InformeEstadoDto,
+  })
+  @ApiResponse({ status: 400, description: 'Solicitud incorrecta.' })
+  @ApiResponse({ status: 404, description: 'Estado no encontrado.' })
+  async put(
+    @Res() res,
+    @Param('id') id: string,
+    @Body() informeEstadoDto: InformeEstadoDto,
+  ) {
+    try {
+      const estadoInforme = await this.informeEstadoService.put(
+        id,
+        informeEstadoDto,
+      );
+      res.status(HttpStatus.OK).json({
+        Success: true,
+        Status: HttpStatus.OK,
+        Message: 'Actualizacion Exitosa',
+        Data: estadoInforme,
+      });
+    } catch (error) {
+      res.status(HttpStatus.BAD_REQUEST).json({
+        Success: false,
+        Status: HttpStatus.BAD_REQUEST,
+        Message:
+          'Error en servicio Put: la peticion contiene un tipo de dato incorrecto o un parametro invalido',
+        Data: error.message,
+      });
+    }
+  }
+
+  @Delete('/:id')
+  @ApiOperation({ summary: 'Eliminar un estado de informe' })
+  @ApiParam({ name: 'id', type: 'string' })
+  @ApiResponse({
+    status: 200,
+    description: 'El estado de informe ha sido eliminado exitosamente.',
+  })
+  @ApiResponse({ status: 404, description: 'Estado no encontrado.' })
+  async delete(@Res() res, @Param('id') id: string) {
+    try {
+      await this.informeEstadoService.delete(id);
+      res.status(HttpStatus.OK).json({
+        Success: true,
+        Status: HttpStatus.OK,
+        Message: 'Eliminacion Exitosa',
+        Data: {
+          _id: id,
+        },
+      });
+    } catch (error) {
+      res.status(HttpStatus.NOT_FOUND).json({
+        Success: false,
+        Status: HttpStatus.NOT_FOUND,
+        Message:
+          'Error en el servicio Delete: la peticion contiene parametros incorrectos',
+        Data: error.message,
+      });
+    }
+  }
+}

--- a/src/informe-estado/informe-estado.module.ts
+++ b/src/informe-estado/informe-estado.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { Informe, InformeSchema } from '../informe/schemas/informe.schema';
+import {
+  InformeEstado,
+  InformeEstadoSchema,
+} from './schemas/informe-estado.schema';
+import { InformeEstadoController } from './informe-estado.controller';
+import { InformeEstadoService } from './informe-estado.service';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: InformeEstado.name, schema: InformeEstadoSchema },
+      { name: Informe.name, schema: InformeSchema },
+    ]),
+  ],
+  controllers: [InformeEstadoController],
+  providers: [InformeEstadoService],
+  exports: [InformeEstadoService],
+})
+export class InformeEstadoModule {}

--- a/src/informe-estado/informe-estado.service.spec.ts
+++ b/src/informe-estado/informe-estado.service.spec.ts
@@ -1,0 +1,319 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { InformeEstadoService } from './informe-estado.service';
+import { getModelToken } from '@nestjs/mongoose';
+import { InformeEstado } from './schemas/informe-estado.schema';
+import { InformeEstadoDto } from './dto/informe-estado.dto';
+import { Informe } from '../informe/schemas/informe.schema';
+import { Model } from 'mongoose';
+import { FilterDto } from '../filters/filters.dto';
+
+const mockInformeEstadoDTO: InformeEstadoDto = {
+  informe_id: '507f1f77bcf86cd799439011',
+  usuario_id: 123,
+  usuario_rol: 'Auditor',
+  observacion: 'Estado inicial del informe',
+  estado_id: 1,
+  fecha_ejecucion_estado: new Date(),
+  activo: true,
+  actual: true,
+};
+
+const mockInformeEstado = {
+  ...mockInformeEstadoDTO,
+  _id: '507f1f77bcf86cd799439012',
+};
+
+const mockInforme = {
+  _id: '507f1f77bcf86cd799439011',
+  auditoria_id: '507f1f77bcf86cd799439010',
+};
+
+describe('InformeEstadoService', () => {
+  let informeEstadoService: InformeEstadoService;
+  let informeEstadoModel: Model<InformeEstado>;
+  let informeModel: Model<Informe>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        InformeEstadoService,
+        {
+          provide: getModelToken(InformeEstado.name),
+          useValue: {
+            create: jest.fn(),
+            find: jest.fn(),
+            findById: jest.fn(),
+            findByIdAndUpdate: jest.fn(),
+            countDocuments: jest.fn(),
+            updateMany: jest.fn(),
+          },
+        },
+        {
+          provide: getModelToken(Informe.name),
+          useValue: {
+            findById: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    informeEstadoService = module.get<InformeEstadoService>(InformeEstadoService);
+    informeEstadoModel = module.get<Model<InformeEstado>>(
+      getModelToken(InformeEstado.name),
+    );
+    informeModel = module.get<Model<Informe>>(
+      getModelToken(Informe.name),
+    );
+  });
+
+  it('Debería estar definido', () => {
+    expect(InformeEstadoService).toBeDefined();
+  });
+
+  describe('post', () => {
+    it('Debería crear y devolver un estado de informe', async () => {
+      jest.spyOn(informeModel, 'findById').mockReturnValue({
+        exec: jest.fn().mockResolvedValue(mockInforme),
+      } as any);
+      
+      jest.spyOn(informeEstadoModel, 'find').mockResolvedValue([]);
+      
+      jest
+        .spyOn(informeEstadoModel, 'create')
+        .mockImplementationOnce(() =>
+          Promise.resolve(mockInformeEstadoDTO as any),
+        );
+
+      const result = await informeEstadoService.post(mockInformeEstadoDTO);
+      expect(result).toEqual(mockInformeEstadoDTO);
+    });
+
+    it('Debería desactivar estados anteriores al crear uno nuevo', async () => {
+      const estadoAnterior = {
+        _id: '507f1f77bcf86cd799439099',
+        informe_id: mockInformeEstadoDTO.informe_id,
+        actual: true,
+      };
+
+      jest.spyOn(informeModel, 'findById').mockReturnValue({
+        exec: jest.fn().mockResolvedValue(mockInforme),
+      } as any);
+      
+      jest.spyOn(informeEstadoModel, 'find').mockResolvedValue([estadoAnterior] as any);
+      
+      const updateManySpy = jest.spyOn(informeEstadoModel, 'updateMany').mockResolvedValue({} as any);
+      
+      jest
+        .spyOn(informeEstadoModel, 'create')
+        .mockImplementationOnce(() =>
+          Promise.resolve(mockInformeEstadoDTO as any),
+        );
+
+      await informeEstadoService.post(mockInformeEstadoDTO);
+      
+      expect(updateManySpy).toHaveBeenCalledWith(
+        {
+          informe_id: mockInformeEstadoDTO.informe_id,
+          actual: true,
+        },
+        { $set: { actual: false } }
+      );
+    });
+
+    it('Debería lanzar un error si el Informe no existe', async () => {
+      jest.spyOn(informeEstadoModel, 'find').mockResolvedValue([]);
+      
+      jest.spyOn(informeModel, 'findById').mockReturnValue({
+        exec: jest.fn().mockResolvedValue(null),
+      } as any);
+
+      await expect(informeEstadoService.post(mockInformeEstadoDTO)).rejects.toThrow(
+        `Informe relacionado con id ${mockInformeEstadoDTO.informe_id} no existe`,
+      );
+    });
+  });
+
+  describe('getAll', () => {
+    it('Debería retornar todos los estados de informe con filtros aplicados', async () => {
+      const mockEstados = [
+        mockInformeEstado,
+        {
+          _id: '507f1f77bcf86cd799439013',
+          informe_id: '507f1f77bcf86cd799439011',
+          usuario_id: 456,
+          estado_id: 2,
+          actual: true,
+          activo: true,
+        },
+      ];
+
+      const mockFilterDto: FilterDto = {
+        query: '',
+        fields: '',
+        sortby: '',
+        order: '',
+        limit: '',
+        offset: '',
+        populate: '',
+      };
+
+      const mockQuery = {
+        sort: jest.fn().mockReturnThis(),
+        populate: jest.fn().mockReturnThis(),
+        lean: jest.fn().mockReturnThis(),
+        exec: jest.fn().mockResolvedValue(mockEstados),
+      };
+
+      jest.spyOn(informeEstadoModel, 'find').mockReturnValue(mockQuery as any);
+
+      const result = await informeEstadoService.getAll(mockFilterDto);
+
+      expect(result).toEqual(mockEstados);
+    });
+  });
+
+  describe('getById', () => {
+    it('Debería retornar un estado de informe por su ID', async () => {
+      jest.spyOn(informeEstadoModel, 'findById').mockReturnValue({
+        exec: jest
+          .fn()
+          .mockResolvedValue(mockInformeEstado as unknown as InformeEstado),
+      } as any);
+
+      const result = await informeEstadoService.getById(mockInformeEstado._id);
+
+      expect(informeEstadoModel.findById).toHaveBeenCalledWith(
+        mockInformeEstado._id,
+      );
+      expect(result).toEqual(mockInformeEstado);
+    });
+
+    it('Debería lanzar un error si el estado de informe no existe', async () => {
+      jest.spyOn(informeEstadoModel, 'findById').mockReturnValue({
+        exec: jest.fn().mockResolvedValue(null),
+      } as any);
+
+      await expect(
+        informeEstadoService.getById(mockInformeEstado._id),
+      ).rejects.toThrow(`${mockInformeEstado._id} no existe`);
+
+      expect(informeEstadoModel.findById).toHaveBeenCalledWith(
+        mockInformeEstado._id,
+      );
+    });
+  });
+
+  describe('put', () => {
+    it('Debería actualizar un estado de informe', async () => {
+      jest.spyOn(informeModel, 'findById').mockReturnValue({
+        exec: jest.fn().mockResolvedValue(mockInforme),
+      } as any);
+      jest.spyOn(informeEstadoModel, 'findByIdAndUpdate').mockReturnValue({
+        exec: jest
+          .fn()
+          .mockResolvedValue(mockInformeEstadoDTO as unknown as InformeEstado),
+      } as any);
+
+      const result = await informeEstadoService.put(
+        mockInformeEstado._id,
+        mockInformeEstadoDTO,
+      );
+
+      expect(informeEstadoModel.findByIdAndUpdate).toHaveBeenCalledWith(
+        mockInformeEstado._id,
+        mockInformeEstadoDTO,
+        { new: true },
+      );
+      expect(result).toEqual(mockInformeEstadoDTO);
+    });
+
+    it('Debería lanzar un error si el estado de informe no existe', async () => {
+      jest.spyOn(informeModel, 'findById').mockReturnValue({
+        exec: jest.fn().mockResolvedValue(mockInforme),
+      } as any);
+      jest.spyOn(informeEstadoModel, 'findByIdAndUpdate').mockReturnValue({
+        exec: jest.fn().mockResolvedValue(null),
+      } as any);
+
+      await expect(
+        informeEstadoService.put(mockInformeEstado._id, mockInformeEstadoDTO),
+      ).rejects.toThrow(`${mockInformeEstado._id} no existe`);
+
+      expect(informeEstadoModel.findByIdAndUpdate).toHaveBeenCalledWith(
+        mockInformeEstado._id,
+        mockInformeEstadoDTO,
+        { new: true },
+      );
+    });
+
+    it('Debería lanzar un error si el Informe relacionado no existe', async () => {
+      jest.spyOn(informeModel, 'findById').mockReturnValue({
+        exec: jest.fn().mockResolvedValue(null),
+      } as any);
+
+      await expect(
+        informeEstadoService.put(mockInformeEstado._id, mockInformeEstadoDTO),
+      ).rejects.toThrow(
+        `Informe relacionado con id ${mockInformeEstadoDTO.informe_id} no existe`,
+      );
+    });
+  });
+
+  describe('delete', () => {
+    it('Debería marcar un estado de informe como inactivo', async () => {
+      jest.spyOn(informeEstadoModel, 'findByIdAndUpdate').mockReturnValue({
+        exec: jest
+          .fn()
+          .mockResolvedValue(mockInformeEstadoDTO as unknown as InformeEstado),
+      } as any);
+
+      const result = await informeEstadoService.delete(mockInformeEstado._id);
+
+      expect(result).toEqual(mockInformeEstadoDTO);
+    });
+
+    it('Debería lanzar un error si el estado de informe no existe', async () => {
+      jest.spyOn(informeEstadoModel, 'findByIdAndUpdate').mockReturnValue({
+        exec: jest.fn().mockResolvedValue(null),
+      } as any);
+
+      await expect(
+        informeEstadoService.delete(mockInformeEstado._id),
+      ).rejects.toThrow(`${mockInformeEstado._id} no existe`);
+    });
+  });
+
+  describe('count', () => {
+    const filterDto: FilterDto = {
+      query: 'actual:true',
+      fields: '',
+      sortby: '',
+      order: '',
+      limit: '',
+      offset: '',
+      populate: '',
+    };
+    
+    it('Debería retornar la cantidad de documentos', async () => {
+      jest.spyOn(informeEstadoModel, 'countDocuments').mockReturnValue({
+        exec: jest.fn().mockResolvedValue(5),
+      } as any);
+
+      const result = await informeEstadoService.count(filterDto);
+
+      expect(result).toBe(5);
+    });
+
+    it('Debería lanzar un error si countDocuments falla', async () => {
+      jest.spyOn(informeEstadoModel, 'countDocuments').mockReturnValue({
+        exec: jest
+          .fn()
+          .mockRejectedValue(new Error('Error al contar documentos')),
+      } as any);
+
+      await expect(informeEstadoService.count(filterDto)).rejects.toThrow(
+        'Error al contar documentos',
+      );
+    });
+  });
+});

--- a/src/informe-estado/informe-estado.service.ts
+++ b/src/informe-estado/informe-estado.service.ts
@@ -1,0 +1,125 @@
+import { Injectable } from '@nestjs/common';
+import { Model } from 'mongoose';
+import { FilterDto } from '../filters/filters.dto';
+import { FiltersService } from '../filters/filters.service';
+import { InformeEstado } from './schemas/informe-estado.schema';
+import { InformeEstadoDto } from './dto/informe-estado.dto';
+import { InjectModel } from '@nestjs/mongoose';
+import { Informe } from '../informe/schemas/informe.schema';
+
+@Injectable()
+export class InformeEstadoService {
+  constructor(
+    @InjectModel(InformeEstado.name)
+    private readonly InformeEstadoModel: Model<InformeEstado>,
+    @InjectModel(Informe.name)
+    private readonly InformeModel: Model<Informe>,
+  ) {}
+
+  private populateFields(): any[] {
+    return [{ path: 'informe_id' }];
+  }
+
+  private async checkRelated(informeEstadoDto: InformeEstadoDto) {
+    if (informeEstadoDto.informe_id) {
+      const informe = await this.InformeModel.findById(
+        informeEstadoDto.informe_id,
+      ).exec();
+      if (!informe) {
+        throw new Error(
+          `Informe relacionado con id ${informeEstadoDto.informe_id} no existe`,
+        );
+      }
+    }
+  }
+
+  async post(informeEstadoDto: InformeEstadoDto): Promise<InformeEstado> {
+  await this.checkRelated(informeEstadoDto);
+  
+  const fecha = new Date();
+  const informeEstadoData = {
+    ...informeEstadoDto,
+    actual: true,
+    activo: true,
+    fecha_ejecucion_estado: fecha,
+  };
+
+  const estadosRelacionados = await this.InformeEstadoModel.find({
+    informe_id: informeEstadoDto.informe_id,
+    actual: true,
+  });
+
+  if (estadosRelacionados.length > 0) {
+    await this.InformeEstadoModel.updateMany(
+      {
+        informe_id: informeEstadoDto.informe_id,
+        actual: true,
+      },
+      { $set: { actual: false } },
+    );
+  }
+
+  return await this.InformeEstadoModel.create(informeEstadoData);
+}
+
+  async getAll(filterDto: FilterDto): Promise<InformeEstado[]> {
+    const filtersService = new FiltersService(filterDto);
+    let populateFields = [];
+    if (filtersService.isPopulated()) {
+      populateFields = this.populateFields();
+    }
+    return await this.InformeEstadoModel.find(
+      filtersService.getQuery(),
+      filtersService.getFields() as any,
+      filtersService.getLimitAndOffset(),
+    )
+      .sort(filtersService.getSortBy())
+      .populate(populateFields)
+      .lean()
+      .exec() as unknown as InformeEstado[];
+  }
+
+  async getById(id: string): Promise<InformeEstado> {
+    const informeEstado = await this.InformeEstadoModel.findById(id).exec();
+    if (!informeEstado) {
+      throw new Error(`${id} no existe`);
+    }
+    return informeEstado;
+  }
+
+  async put(
+    id: string,
+    informeEstadoDto: InformeEstadoDto,
+  ): Promise<InformeEstado> {
+    await this.checkRelated(informeEstadoDto);
+    const update = await this.InformeEstadoModel.findByIdAndUpdate(
+      id,
+      informeEstadoDto,
+      { new: true },
+    ).exec();
+    if (!update) {
+      throw new Error(`${id} no existe`);
+    }
+    return update;
+  }
+
+  async delete(id: string): Promise<InformeEstado> {
+    const deleted = await this.InformeEstadoModel.findByIdAndUpdate(
+      id,
+      { activo: false },
+      { new: true },
+    ).exec();
+    if (!deleted) {
+      throw new Error(`${id} no existe`);
+    }
+    return deleted;
+  }
+
+  async count(filterDto: FilterDto): Promise<number> {
+    const filtersService = new FiltersService(filterDto);
+
+    return await this.InformeEstadoModel.countDocuments(
+      filtersService.getQuery(),
+    ).exec();
+  }
+}

--- a/src/informe-estado/schemas/informe-estado.schema.ts
+++ b/src/informe-estado/schemas/informe-estado.schema.ts
@@ -1,0 +1,34 @@
+import { Schema, Prop, SchemaFactory } from '@nestjs/mongoose';
+import { Document, Types } from 'mongoose';
+import { Informe } from '../../informe/schemas/informe.schema';
+
+@Schema({ collection: 'informe_estado' })
+export class InformeEstado extends Document {
+  @Prop({ required: false, type: Types.ObjectId, ref: Informe.name })
+  informe_id: Informe | Types.ObjectId;
+
+  @Prop({ required: false })
+  usuario_id: number;
+
+  @Prop({ required: false })
+  usuario_rol: string;
+
+  @Prop({ required: false })
+  observacion: string;
+
+  @Prop({ required: false })
+  actual: boolean;
+
+  @Prop({ required: false })
+  estado_id: number;
+
+  @Prop({ required: false })
+  fecha_ejecucion_estado: Date;
+
+  @Prop({ required: false })
+  activo: boolean;
+}
+
+export const InformeEstadoSchema = SchemaFactory.createForClass(InformeEstado);
+
+InformeEstadoSchema.set('versionKey', false);

--- a/src/informe/dto/informe.dto.ts
+++ b/src/informe/dto/informe.dto.ts
@@ -26,6 +26,9 @@ export class InformeDTO {
     readonly notas?: string;
 
     @ApiProperty()
+    readonly estado_id?: number;
+
+    @ApiProperty()
     readonly preliminar_auditor_id?: number;
 
     @ApiProperty()

--- a/src/informe/informe.controller.spec.ts
+++ b/src/informe/informe.controller.spec.ts
@@ -4,6 +4,7 @@ import { InformeDTO } from './dto/informe.dto';
 import { InformeService } from './informe.service';
 import { HttpStatus } from '@nestjs/common';
 import { FilterDto } from '../filters/filters.dto';
+import { InformeEstadoService } from '../informe-estado/informe-estado.service';
 
 const mockInformeDto: InformeDTO = {
   auditoria_id: '507f1f77bcf86cd799439011',
@@ -36,6 +37,13 @@ describe('InformeController', () => {
             delete: jest.fn(),
             count: jest.fn(),
             getHallazgosByInforme: jest.fn(),
+          },
+        },
+        {
+          provide: InformeEstadoService,  
+          useValue: {
+            getAll: jest.fn(),
+            getById: jest.fn(),
           },
         },
       ],

--- a/src/informe/informe.controller.ts
+++ b/src/informe/informe.controller.ts
@@ -20,11 +20,14 @@ import {
     ApiParam,
     ApiBody,
 } from '@nestjs/swagger';
+import { InformeEstadoService } from '../informe-estado/informe-estado.service';
 
 @ApiTags('informe')
 @Controller('informe')
 export class InformeController {
-    constructor(private informeService: InformeService) { }
+    constructor(private informeService: InformeService,
+        private informeEstadoService: InformeEstadoService
+    ) { }
 
     @Post()
     @ApiOperation({ summary: 'Crear un nuevo informe' })
@@ -208,4 +211,95 @@ export class InformeController {
             });
         }
     }
+
+    @Get('/:id/estados')
+  @ApiOperation({ summary: 'Obtener todos los estados de un informe (historial completo)' })
+  @ApiParam({ name: 'id', type: 'string', description: 'ID del informe' })
+  @ApiResponse({
+    status: 200,
+    description: 'Devuelve todos los estados del informe.',
+  })
+  @ApiResponse({ status: 404, description: 'Informe no encontrado o sin estados.' })
+  async getEstados(
+    @Res() res,
+    @Param('id') id: string
+  ) {
+    try {
+      await this.informeService.getById(id);
+      
+      const filterDto = {
+        query: `informe_id:${id}`,
+        fields: '',
+        sortby: 'fecha_ejecucion_estado',
+        order: 'desc',
+        limit: '100',
+        offset: '0',
+        populate: 'false',
+      };
+      
+      const estados = await this.informeEstadoService.getAll(filterDto);
+      
+      res.status(HttpStatus.OK).json({
+        Success: true,
+        Status: HttpStatus.OK,
+        Message: 'Peticion Exitosa',
+        Data: estados,
+        MetaData: { Count: estados.length },
+      });
+    } catch (error) {
+      res.status(HttpStatus.NOT_FOUND).json({
+        Success: false,
+        Status: HttpStatus.NOT_FOUND,
+        Message: 'Error al obtener estados del informe',
+        Data: error.message,
+      });
+    }
+  }
+
+  @Get('/:id/estado-actual')
+  @ApiOperation({ summary: 'Obtener el estado actual de un informe' })
+  @ApiParam({ name: 'id', type: 'string', description: 'ID del informe' })
+  @ApiResponse({
+    status: 200,
+    description: 'Devuelve el estado actual del informe.',
+  })
+  @ApiResponse({ status: 404, description: 'Informe no encontrado o sin estado actual.' })
+  async getEstadoActual(
+    @Res() res,
+    @Param('id') id: string
+  ) {
+    try {
+      await this.informeService.getById(id);
+      
+      const filterDto = {
+        query: `informe_id:${id},actual:true`,
+        fields: '',
+        sortby: 'fecha_ejecucion_estado',
+        order: 'desc',
+        limit: '1',
+        offset: '0',
+        populate: 'false',
+      };
+      
+      const estados = await this.informeEstadoService.getAll(filterDto);
+      
+      if (estados.length === 0) {
+        throw new Error('El informe no tiene un estado actual');
+      }
+      
+      res.status(HttpStatus.OK).json({
+        Success: true,
+        Status: HttpStatus.OK,
+        Message: 'Peticion Exitosa',
+        Data: estados[0],
+      });
+    } catch (error) {
+      res.status(HttpStatus.NOT_FOUND).json({
+        Success: false,
+        Status: HttpStatus.NOT_FOUND,
+        Message: 'Error al obtener estado actual del informe',
+        Data: error.message,
+      });
+    }
+  }
 }

--- a/src/informe/informe.module.ts
+++ b/src/informe/informe.module.ts
@@ -4,6 +4,7 @@ import { InformeService } from './informe.service';
 import { MongooseModule } from '@nestjs/mongoose';
 import { Informe, InformeSchema } from './schemas/informe.schema';
 import { Tema, TemaSchema } from '../tema/schemas/tema.schema';
+import { InformeEstadoModule } from '../informe-estado/informe-estado.module';
 
 @Module({
   imports: [
@@ -11,6 +12,7 @@ import { Tema, TemaSchema } from '../tema/schemas/tema.schema';
       { name: Informe.name, schema: InformeSchema },
       { name: Tema.name, schema: TemaSchema },
     ]),
+    InformeEstadoModule,
   ],
   controllers: [InformeController],
   providers: [InformeService],

--- a/src/informe/informe.service.spec.ts
+++ b/src/informe/informe.service.spec.ts
@@ -83,17 +83,7 @@ describe('InformeService', () => {
 
   describe('getAll', () => {
     it('Debería retornar todos los informes con filtros aplicados', async () => {
-      const mockInformes = [
-        mockInforme,
-        {
-          _id: '507f1f77bcf86cd799439013',
-          auditoria_id: '507f1f77bcf86cd799439011',
-          fecha_emision: new Date('2024-01-21'),
-          activo: true,
-          fecha_creacion: new Date(),
-        },
-      ];
-
+      const mockInformes = [mockInforme, { ...mockInforme, _id: '507f1f77bcf86cd799439013' }];
       const mockFilterDto: FilterDto = {
         query: '',
         fields: '',
@@ -107,13 +97,13 @@ describe('InformeService', () => {
       const mockQuery = {
         sort: jest.fn().mockReturnThis(),
         populate: jest.fn().mockReturnThis(),
+        lean: jest.fn().mockReturnThis(),  
         exec: jest.fn().mockResolvedValue(mockInformes),
       };
 
       jest.spyOn(informeModel, 'find').mockReturnValue(mockQuery as any);
 
       const result = await informeService.getAll(mockFilterDto);
-
       expect(result).toEqual(mockInformes);
     });
   });

--- a/src/informe/schemas/informe.schema.ts
+++ b/src/informe/schemas/informe.schema.ts
@@ -14,6 +14,7 @@ export class Informe extends Document {
   @Prop() observaciones_conclusiones: string;
   @Prop() notas: string;
 
+  @Prop() estado_id: number;
   @Prop() preliminar_auditor_id: number;
   @Prop() final_auditor_id: number;
   @Prop() preliminar_auditado_id: number;

--- a/swagger.json
+++ b/swagger.json
@@ -1848,6 +1848,288 @@
         ]
       }
     },
+    "/informe/{id}/estados": {
+      "get": {
+        "operationId": "InformeController_getEstados",
+        "summary": "Obtener todos los estados de un informe (historial completo)",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "ID del informe",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Devuelve todos los estados del informe."
+          },
+          "404": {
+            "description": "Informe no encontrado o sin estados."
+          }
+        },
+        "tags": [
+          "informe"
+        ]
+      }
+    },
+    "/informe/{id}/estado-actual": {
+      "get": {
+        "operationId": "InformeController_getEstadoActual",
+        "summary": "Obtener el estado actual de un informe",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "ID del informe",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Devuelve el estado actual del informe."
+          },
+          "404": {
+            "description": "Informe no encontrado o sin estado actual."
+          }
+        },
+        "tags": [
+          "informe"
+        ]
+      }
+    },
+    "/informe-estado": {
+      "post": {
+        "operationId": "InformeEstadoController_post",
+        "summary": "Crear un nuevo estado de informe",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InformeEstadoDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "El estado de informe ha sido creado exitosamente.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InformeEstadoDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Solicitud incorrecta."
+          }
+        },
+        "tags": [
+          "informe-estado"
+        ]
+      },
+      "get": {
+        "operationId": "InformeEstadoController_getAll",
+        "summary": "Obtener todos los estados de informe",
+        "parameters": [
+          {
+            "name": "query",
+            "required": false,
+            "in": "query",
+            "description": " query-Filter.e.g.col1:v1,col2:v2… ",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "fields",
+            "required": false,
+            "in": "query",
+            "description": "fields - Fields returned. e.g. col1,col2 …",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortby",
+            "required": false,
+            "in": "query",
+            "description": "sortby - Sorted-by fields. e.g. col1,col2 …",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "order",
+            "required": false,
+            "in": "query",
+            "description": "order - Order corresponding to each sortby field, if single value, apply to all sortby fields. e.g. desc,asc …",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "limit - Limit the size of result set. Must be an integer",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "offset",
+            "required": false,
+            "in": "query",
+            "description": "offset - Start position of result set. Must be an integer",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "populate",
+            "required": false,
+            "in": "query",
+            "description": "populate - show subqueries. Must be a boolean",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Devuelve todos los estados de informe.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/InformeEstadoDto"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "informe-estado"
+        ]
+      }
+    },
+    "/informe-estado/{id}": {
+      "get": {
+        "operationId": "InformeEstadoController_getById",
+        "summary": "Obtener un estado de informe por Id",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Devuelve el estado de informe.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InformeEstadoDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Estado no encontrado."
+          }
+        },
+        "tags": [
+          "informe-estado"
+        ]
+      },
+      "put": {
+        "operationId": "InformeEstadoController_put",
+        "summary": "Actualizar un estado de informe",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InformeEstadoDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "El estado de informe ha sido actualizado exitosamente.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InformeEstadoDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Solicitud incorrecta."
+          },
+          "404": {
+            "description": "Estado no encontrado."
+          }
+        },
+        "tags": [
+          "informe-estado"
+        ]
+      },
+      "delete": {
+        "operationId": "InformeEstadoController_delete",
+        "summary": "Eliminar un estado de informe",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "El estado de informe ha sido eliminado exitosamente."
+          },
+          "404": {
+            "description": "Estado no encontrado."
+          }
+        },
+        "tags": [
+          "informe-estado"
+        ]
+      }
+    },
     "/tema": {
       "post": {
         "operationId": "TemaController_post",
@@ -2757,6 +3039,9 @@
           "notas": {
             "type": "string"
           },
+          "estado_id": {
+            "type": "number"
+          },
           "preliminar_auditor_id": {
             "type": "number"
           },
@@ -2783,11 +3068,52 @@
           "informe_final",
           "observaciones_conclusiones",
           "notas",
+          "estado_id",
           "preliminar_auditor_id",
           "final_auditor_id",
           "preliminar_auditado_id",
           "activo",
           "fecha_creacion"
+        ]
+      },
+      "InformeEstadoDto": {
+        "type": "object",
+        "properties": {
+          "informe_id": {
+            "type": "string"
+          },
+          "usuario_id": {
+            "type": "number"
+          },
+          "usuario_rol": {
+            "type": "string"
+          },
+          "observacion": {
+            "type": "string"
+          },
+          "actual": {
+            "type": "boolean"
+          },
+          "estado_id": {
+            "type": "number"
+          },
+          "fecha_ejecucion_estado": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "activo": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "informe_id",
+          "usuario_id",
+          "usuario_rol",
+          "observacion",
+          "actual",
+          "estado_id",
+          "fecha_ejecucion_estado",
+          "activo"
         ]
       },
       "TemaDTO": {


### PR DESCRIPTION
Se completó la implementación del CRUD para la gestión de estados de informe en el microservicio, cumpliendo con los ajustes del modelo de datos y las validaciones de negocio requeridas.

**Avances realizados**

- Endpoints del Microservicio: Implementación de métodos POST, GET (all/id), PUT y DELETE para la colección informe-estado.
- Consultas Especializadas: Desarrollo de endpoints específicos para obtener el historial completo y el estado actual filtrado por ID de informe.
- Lógica de Negocio: Manejo automático de estado actual único, desactivando registros anteriores al crear uno nuevo.
- Validaciones: Verificación de existencia del informe relacionado antes de realizar operaciones de escritura.

**Resultados de Tests**

Se validó la implementación mediante 25 pruebas unitarias:

- Controller: 11 tests aprobados.
- Service: 14 tests aprobados.
- Estado final: PASS en todos los casos de uso y validaciones.