### PR TITLE
refactor: desacoplamiento de endpoints subtema y hallazgo #490

### DIFF
--- a/src/tema/dto/hallazgo.dto.ts
+++ b/src/tema/dto/hallazgo.dto.ts
@@ -1,5 +1,49 @@
 import { ApiProperty } from '@nestjs/swagger';
 
+// DTO para crear un nuevo hallazgo
+export class CreateHallazgoDTO {
+  @ApiProperty({ description: 'ID del subtema padre' })
+  readonly subtema_id: string;
+
+  @ApiProperty({ description: 'Título del hallazgo' })
+  readonly titulo: string;
+
+  @ApiProperty({ description: 'Criterio del hallazgo' })
+  readonly criterio: string;
+
+  @ApiProperty({ description: 'Descripción del hallazgo' })
+  readonly descripcion: string;
+
+  @ApiProperty({ 
+    required: false, 
+    default: true,
+    description: 'Estado activo del hallazgo' 
+  })
+  activo?: boolean;
+}
+
+// DTO para actualizar un hallazgo existente
+export class UpdateHallazgoDTO {
+  @ApiProperty({ 
+    required: false,
+    description: 'Título del hallazgo' 
+  })
+  readonly titulo?: string;
+
+  @ApiProperty({ 
+    required: false,
+    description: 'Criterio del hallazgo' 
+  })
+  readonly criterio?: string;
+
+  @ApiProperty({ 
+    required: false,
+    description: 'Descripción del hallazgo' 
+  })
+  readonly descripcion?: string;
+}
+
+// DTO completo para respuestas (mantener el original)
 export class HallazgoDTO {
   @ApiProperty()
   readonly titulo: string;

--- a/src/tema/dto/subtema.dto.ts
+++ b/src/tema/dto/subtema.dto.ts
@@ -1,5 +1,31 @@
 import { ApiProperty } from '@nestjs/swagger';
 
+// DTO para crear un nuevo subtema
+export class CreateSubtemaDTO {
+  @ApiProperty({ description: 'ID del tema padre' })
+  readonly tema_id: string;
+
+  @ApiProperty({ description: 'Título del subtema' })
+  readonly titulo: string;
+
+  @ApiProperty({ 
+    required: false, 
+    default: true,
+    description: 'Estado activo del subtema' 
+  })
+  activo?: boolean;
+}
+
+// DTO para actualizar un subtema existente
+export class UpdateSubtemaDTO {
+  @ApiProperty({ 
+    required: false,
+    description: 'Título del subtema' 
+  })
+  readonly titulo?: string;
+}
+
+// DTO completo para respuestas (mantener el original)
 export class SubtemaDTO {
   @ApiProperty()
   readonly titulo: string;
@@ -7,6 +33,6 @@ export class SubtemaDTO {
   @ApiProperty()
   activo: boolean;
 
-  @ApiProperty()
+  @ApiProperty({ required: false })
   readonly hallazgo?: any[];
 }

--- a/src/tema/dto/tema.dto.ts
+++ b/src/tema/dto/tema.dto.ts
@@ -1,18 +1,26 @@
 import { ApiProperty } from '@nestjs/swagger';
 
 export class TemaDTO {
-  @ApiProperty()
+  @ApiProperty({ description: 'ID del informe padre' })
   readonly informe_id: string;
 
-  @ApiProperty()
+  @ApiProperty({ description: 'Título del tema' })
   readonly titulo: string;
 
-  @ApiProperty()
-  activo: boolean;
+  @ApiProperty({ required: false, default: true })
+  activo?: boolean;
 
-  @ApiProperty()
+  @ApiProperty({ required: false })
   readonly subtema?: any[];
 
-  @ApiProperty()
-  fecha_creacion: Date;
+  @ApiProperty({ required: false })
+  fecha_creacion?: Date;
+}
+
+export class UpdateTemaDTO {
+  @ApiProperty({ 
+    required: false,
+    description: 'Título del tema' 
+  })
+  readonly titulo?: string;
 }

--- a/src/tema/hallazgo.controller.spec.ts
+++ b/src/tema/hallazgo.controller.spec.ts
@@ -1,0 +1,234 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HallazgoController } from './hallazgo.controller';
+import { TemaService } from './tema.service';
+import { CreateHallazgoDTO, UpdateHallazgoDTO } from './dto/hallazgo.dto';
+import { HttpStatus } from '@nestjs/common';
+import { FilterDto } from '../filters/filters.dto';
+
+const mockCreateHallazgoDto: CreateHallazgoDTO = {
+  subtema_id: '507f1f77bcf86cd799439013',
+  titulo: 'Falta de documentación',
+  criterio: 'Norma ISO 9001',
+  descripcion: 'No se encontró evidencia',
+  activo: true,
+};
+
+const mockUpdateHallazgoDto: UpdateHallazgoDTO = {
+  titulo: 'Falta de documentación actualizada',
+  criterio: 'Norma ISO 9001',
+  descripcion: 'Descripción actualizada'
+};
+
+const mockHallazgo = {
+  _id: '507f1f77bcf86cd799439014',
+  titulo: 'Falta de documentación',
+  criterio: 'Norma ISO 9001',
+  descripcion: 'No se encontró evidencia',
+  activo: true,
+  subtema: {
+    _id: '507f1f77bcf86cd799439013',
+    titulo: 'Archivo General',
+  },
+  tema: {
+    _id: '507f1f77bcf86cd799439011',
+    titulo: 'Gestión Documental',
+  },
+};
+
+describe('HallazgoController', () => {
+  let controller: HallazgoController;
+  let service: TemaService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [HallazgoController],
+      providers: [
+        {
+          provide: TemaService,
+          useValue: {
+            agregarHallazgo: jest.fn(),
+            getAllHallazgos: jest.fn(),
+            countHallazgos: jest.fn(),
+            getHallazgoById: jest.fn(),
+            updateHallazgo: jest.fn(),
+            deleteHallazgo: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<HallazgoController>(HallazgoController);
+    service = module.get<TemaService>(TemaService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('Debería crear un hallazgo correctamente', async () => {
+      jest.spyOn(service, 'agregarHallazgo').mockResolvedValue(mockHallazgo as any);
+
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      await controller.create(res as any, mockCreateHallazgoDto);
+
+      expect(service.agregarHallazgo).toHaveBeenCalledWith(
+        mockCreateHallazgoDto.subtema_id,
+        mockCreateHallazgoDto,
+      );
+      expect(res.status).toHaveBeenCalledWith(HttpStatus.CREATED);
+      expect(res.json).toHaveBeenCalledWith({
+        Success: true,
+        Status: HttpStatus.CREATED,
+        Message: 'Hallazgo creado exitosamente',
+        Data: mockHallazgo,
+      });
+    });
+
+    it('Debería retornar BadRequest con error', async () => {
+      const mockError = new Error('Subtema no existe');
+
+      jest.spyOn(service, 'agregarHallazgo').mockRejectedValue(mockError);
+
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      await controller.create(res as any, mockCreateHallazgoDto);
+
+      expect(res.status).toHaveBeenCalledWith(HttpStatus.BAD_REQUEST);
+      expect(res.json).toHaveBeenCalledWith({
+        Success: false,
+        Status: HttpStatus.BAD_REQUEST,
+        Message: 'Error al crear hallazgo',
+        Data: mockError.message,
+      });
+    });
+  });
+
+  describe('getAll', () => {
+    const mockFilterDto: FilterDto = {
+      query: 'subtema_id:507f1f77bcf86cd799439013',
+      fields: '',
+      sortby: '',
+      order: '',
+      limit: '',
+      offset: '',
+      populate: '',
+    };
+
+    it('Debería retornar todos los hallazgos', async () => {
+      const mockHallazgos = [mockHallazgo];
+
+      jest.spyOn(service, 'getAllHallazgos').mockResolvedValue(mockHallazgos);
+      jest.spyOn(service, 'countHallazgos').mockResolvedValue(1);
+
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      await controller.getAll(res as any, mockFilterDto);
+
+      expect(service.getAllHallazgos).toHaveBeenCalledWith(mockFilterDto);
+      expect(service.countHallazgos).toHaveBeenCalledWith(mockFilterDto);
+      expect(res.status).toHaveBeenCalledWith(HttpStatus.OK);
+      expect(res.json).toHaveBeenCalledWith({
+        Success: true,
+        Status: HttpStatus.OK,
+        Message: 'Peticion Exitosa',
+        Data: mockHallazgos,
+        MetaData: { Count: 1 },
+      });
+    });
+  });
+
+  describe('getById', () => {
+    it('Debería retornar un hallazgo por ID', async () => {
+      jest.spyOn(service, 'getHallazgoById').mockResolvedValue(mockHallazgo);
+
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      await controller.getById(res as any, mockHallazgo._id);
+
+      expect(service.getHallazgoById).toHaveBeenCalledWith(mockHallazgo._id);
+      expect(res.status).toHaveBeenCalledWith(HttpStatus.OK);
+      expect(res.json).toHaveBeenCalledWith({
+        Success: true,
+        Status: HttpStatus.OK,
+        Message: 'Peticion Exitosa',
+        Data: mockHallazgo,
+      });
+    });
+
+    it('Debería retornar NotFound con ID inválido', async () => {
+      const mockError = new Error('Hallazgo no existe');
+
+      jest.spyOn(service, 'getHallazgoById').mockRejectedValue(mockError);
+
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      await controller.getById(res as any, 'invalid-id');
+
+      expect(res.status).toHaveBeenCalledWith(HttpStatus.NOT_FOUND);
+      expect(res.json).toHaveBeenCalledWith({
+        Success: false,
+        Status: HttpStatus.NOT_FOUND,
+        Message: 'Hallazgo no encontrado',
+        Data: mockError.message,
+      });
+    });
+  });
+
+  describe('update', () => {
+    it('Debería actualizar un hallazgo correctamente', async () => {
+      jest.spyOn(service, 'updateHallazgo').mockResolvedValue(mockHallazgo as any);
+
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      await controller.update(res as any, mockHallazgo._id, mockUpdateHallazgoDto);
+
+      expect(service.updateHallazgo).toHaveBeenCalledWith(
+        mockHallazgo._id,
+        mockUpdateHallazgoDto,
+      );
+      expect(res.status).toHaveBeenCalledWith(HttpStatus.OK);
+    });
+  });
+
+  describe('delete', () => {
+    it('Debería eliminar un hallazgo correctamente', async () => {
+      jest.spyOn(service, 'deleteHallazgo').mockResolvedValue(mockHallazgo as any);
+
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      await controller.delete(res as any, mockHallazgo._id);
+
+      expect(service.deleteHallazgo).toHaveBeenCalledWith(mockHallazgo._id);
+      expect(res.status).toHaveBeenCalledWith(HttpStatus.OK);
+      expect(res.json).toHaveBeenCalledWith({
+        Success: true,
+        Status: HttpStatus.OK,
+        Message: 'Hallazgo eliminado exitosamente',
+        Data: mockHallazgo,
+      });
+    });
+  });
+});

--- a/src/tema/hallazgo.controller.ts
+++ b/src/tema/hallazgo.controller.ts
@@ -1,0 +1,184 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpStatus,
+  Param,
+  Post,
+  Put,
+  Query,
+  Res,
+} from '@nestjs/common';
+import { TemaService } from './tema.service';
+import { CreateHallazgoDTO, UpdateHallazgoDTO } from './dto/hallazgo.dto';
+import { FilterDto } from '../filters/filters.dto';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiBody,
+  ApiQuery,
+} from '@nestjs/swagger';
+import { ParseObjectIdPipe } from '../pipes/parse-object-id/parse-object-id.pipe';
+
+@ApiTags('hallazgo')
+@Controller('hallazgo')
+export class HallazgoController {
+  constructor(private temaService: TemaService) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Crear un nuevo hallazgo' })
+  @ApiBody({ type: CreateHallazgoDTO })
+  @ApiResponse({
+    status: 201,
+    description: 'El hallazgo ha sido creado exitosamente.',
+  })
+  @ApiResponse({ status: 400, description: 'Solicitud incorrecta.' })
+  async create(
+    @Res() res,
+    @Body(new ParseObjectIdPipe(['subtema_id'])) createHallazgoDTO: CreateHallazgoDTO,
+  ) {
+    try {
+      const tema = await this.temaService.agregarHallazgo(
+        createHallazgoDTO.subtema_id,
+        createHallazgoDTO,
+      );
+      res.status(HttpStatus.CREATED).json({
+        Success: true,
+        Status: HttpStatus.CREATED,
+        Message: 'Hallazgo creado exitosamente',
+        Data: tema,
+      });
+    } catch (error) {
+      res.status(HttpStatus.BAD_REQUEST).json({
+        Success: false,
+        Status: HttpStatus.BAD_REQUEST,
+        Message: 'Error al crear hallazgo',
+        Data: error.message,
+      });
+    }
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'Obtener todos los hallazgos' })
+  @ApiQuery({
+    name: 'query',
+    required: false,
+    description: 'Filtros en formato query. Ejemplo: subtema_id:507f1f77bcf86cd799439011',
+    example: 'subtema_id:507f1f77bcf86cd799439011',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Devuelve todos los hallazgos filtrados.',
+  })
+  async getAll(@Res() res, @Query() filterDto: FilterDto) {
+    try {
+      const hallazgos = await this.temaService.getAllHallazgos(filterDto);
+      const counts = await this.temaService.countHallazgos(filterDto);
+
+      res.status(HttpStatus.OK).json({
+        Success: true,
+        Status: HttpStatus.OK,
+        Message: 'Peticion Exitosa',
+        Data: hallazgos,
+        MetaData: { Count: counts },
+      });
+    } catch (error) {
+      res.status(HttpStatus.NOT_FOUND).json({
+        Success: false,
+        Status: HttpStatus.NOT_FOUND,
+        Message: 'Error al obtener hallazgos',
+        Data: error.message,
+      });
+    }
+  }
+
+  @Get('/:id')
+  @ApiOperation({ summary: 'Obtener un hallazgo por su ID' })
+  @ApiParam({ name: 'id', type: 'string', description: 'ID del hallazgo' })
+  @ApiResponse({
+    status: 200,
+    description: 'Devuelve el hallazgo con información del subtema y tema padre.',
+  })
+  @ApiResponse({ status: 404, description: 'Hallazgo no encontrado.' })
+  async getById(@Res() res, @Param('id') id: string) {
+    try {
+      const hallazgo = await this.temaService.getHallazgoById(id);
+      res.status(HttpStatus.OK).json({
+        Success: true,
+        Status: HttpStatus.OK,
+        Message: 'Peticion Exitosa',
+        Data: hallazgo,
+      });
+    } catch (error) {
+      res.status(HttpStatus.NOT_FOUND).json({
+        Success: false,
+        Status: HttpStatus.NOT_FOUND,
+        Message: 'Hallazgo no encontrado',
+        Data: error.message,
+      });
+    }
+  }
+
+  @Put('/:id')
+  @ApiOperation({ summary: 'Actualizar un hallazgo por su ID' })
+  @ApiParam({ name: 'id', type: 'string', description: 'ID del hallazgo' })
+  @ApiBody({ type: UpdateHallazgoDTO })
+  @ApiResponse({
+    status: 200,
+    description: 'El hallazgo ha sido actualizado exitosamente.',
+  })
+  @ApiResponse({ status: 400, description: 'Solicitud incorrecta.' })
+  @ApiResponse({ status: 404, description: 'Hallazgo no encontrado.' })
+  async update(
+    @Res() res,
+    @Param('id') id: string,
+    @Body() updateHallazgoDTO: UpdateHallazgoDTO,
+  ) {
+    try {
+      const tema = await this.temaService.updateHallazgo(id, updateHallazgoDTO);
+      res.status(HttpStatus.OK).json({
+        Success: true,
+        Status: HttpStatus.OK,
+        Message: 'Hallazgo actualizado exitosamente',
+        Data: tema,
+      });
+    } catch (error) {
+      res.status(HttpStatus.BAD_REQUEST).json({
+        Success: false,
+        Status: HttpStatus.BAD_REQUEST,
+        Message: 'Error al actualizar hallazgo',
+        Data: error.message,
+      });
+    }
+  }
+
+  @Delete('/:id')
+  @ApiOperation({ summary: 'Eliminar un hallazgo por su ID' })
+  @ApiParam({ name: 'id', type: 'string', description: 'ID del hallazgo' })
+  @ApiResponse({
+    status: 200,
+    description: 'El hallazgo ha sido eliminado exitosamente.',
+  })
+  @ApiResponse({ status: 404, description: 'Hallazgo no encontrado.' })
+  async delete(@Res() res, @Param('id') id: string) {
+    try {
+      const tema = await this.temaService.deleteHallazgo(id);
+      res.status(HttpStatus.OK).json({
+        Success: true,
+        Status: HttpStatus.OK,
+        Message: 'Hallazgo eliminado exitosamente',
+        Data: tema,
+      });
+    } catch (error) {
+      res.status(HttpStatus.NOT_FOUND).json({
+        Success: false,
+        Status: HttpStatus.NOT_FOUND,
+        Message: 'Error al eliminar hallazgo',
+        Data: error.message,
+      });
+    }
+  }
+}

--- a/src/tema/subtema.controller.spec.ts
+++ b/src/tema/subtema.controller.spec.ts
@@ -1,0 +1,225 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SubtemaController } from './subtema.controller';
+import { TemaService } from './tema.service';
+import { CreateSubtemaDTO, UpdateSubtemaDTO } from './dto/subtema.dto';
+import { HttpStatus } from '@nestjs/common';
+import { FilterDto } from '../filters/filters.dto';
+
+const mockCreateSubtemaDto: CreateSubtemaDTO = {
+  tema_id: '507f1f77bcf86cd799439011',
+  titulo: 'Archivo General',
+  activo: true,
+};
+
+const mockUpdateSubtemaDto: UpdateSubtemaDTO = {
+  titulo: 'Archivo General Actualizado'
+};
+
+const mockSubtema = {
+  _id: '507f1f77bcf86cd799439013',
+  titulo: 'Archivo General',
+  activo: true,
+  hallazgo: [],
+  tema: {
+    _id: '507f1f77bcf86cd799439011',
+    titulo: 'Gestión Documental',
+  },
+};
+
+describe('SubtemaController', () => {
+  let controller: SubtemaController;
+  let service: TemaService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SubtemaController],
+      providers: [
+        {
+          provide: TemaService,
+          useValue: {
+            agregarSubtema: jest.fn(),
+            getAllSubtemas: jest.fn(),
+            countSubtemas: jest.fn(),
+            getSubtemaById: jest.fn(),
+            updateSubtema: jest.fn(),
+            deleteSubtema: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<SubtemaController>(SubtemaController);
+    service = module.get<TemaService>(TemaService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('Debería crear un subtema correctamente', async () => {
+      jest.spyOn(service, 'agregarSubtema').mockResolvedValue(mockSubtema as any);
+
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      await controller.create(res as any, mockCreateSubtemaDto);
+
+      expect(service.agregarSubtema).toHaveBeenCalledWith(
+        mockCreateSubtemaDto.tema_id,
+        mockCreateSubtemaDto,
+      );
+      expect(res.status).toHaveBeenCalledWith(HttpStatus.CREATED);
+      expect(res.json).toHaveBeenCalledWith({
+        Success: true,
+        Status: HttpStatus.CREATED,
+        Message: 'Subtema creado exitosamente',
+        Data: mockSubtema,
+      });
+    });
+
+    it('Debería retornar BadRequest con error', async () => {
+      const mockError = new Error('Tema no existe');
+
+      jest.spyOn(service, 'agregarSubtema').mockRejectedValue(mockError);
+
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      await controller.create(res as any, mockCreateSubtemaDto);
+
+      expect(res.status).toHaveBeenCalledWith(HttpStatus.BAD_REQUEST);
+      expect(res.json).toHaveBeenCalledWith({
+        Success: false,
+        Status: HttpStatus.BAD_REQUEST,
+        Message: 'Error al crear subtema',
+        Data: mockError.message,
+      });
+    });
+  });
+
+  describe('getAll', () => {
+    const mockFilterDto: FilterDto = {
+      query: 'tema_id:507f1f77bcf86cd799439011',
+      fields: '',
+      sortby: '',
+      order: '',
+      limit: '',
+      offset: '',
+      populate: '',
+    };
+
+    it('Debería retornar todos los subtemas', async () => {
+      const mockSubtemas = [mockSubtema];
+
+      jest.spyOn(service, 'getAllSubtemas').mockResolvedValue(mockSubtemas);
+      jest.spyOn(service, 'countSubtemas').mockResolvedValue(1);
+
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      await controller.getAll(res as any, mockFilterDto);
+
+      expect(service.getAllSubtemas).toHaveBeenCalledWith(mockFilterDto);
+      expect(service.countSubtemas).toHaveBeenCalledWith(mockFilterDto);
+      expect(res.status).toHaveBeenCalledWith(HttpStatus.OK);
+      expect(res.json).toHaveBeenCalledWith({
+        Success: true,
+        Status: HttpStatus.OK,
+        Message: 'Peticion Exitosa',
+        Data: mockSubtemas,
+        MetaData: { Count: 1 },
+      });
+    });
+  });
+
+  describe('getById', () => {
+    it('Debería retornar un subtema por ID', async () => {
+      jest.spyOn(service, 'getSubtemaById').mockResolvedValue(mockSubtema);
+
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      await controller.getById(res as any, mockSubtema._id);
+
+      expect(service.getSubtemaById).toHaveBeenCalledWith(mockSubtema._id);
+      expect(res.status).toHaveBeenCalledWith(HttpStatus.OK);
+      expect(res.json).toHaveBeenCalledWith({
+        Success: true,
+        Status: HttpStatus.OK,
+        Message: 'Peticion Exitosa',
+        Data: mockSubtema,
+      });
+    });
+
+    it('Debería retornar NotFound con ID inválido', async () => {
+      const mockError = new Error('Subtema no existe');
+
+      jest.spyOn(service, 'getSubtemaById').mockRejectedValue(mockError);
+
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      await controller.getById(res as any, 'invalid-id');
+
+      expect(res.status).toHaveBeenCalledWith(HttpStatus.NOT_FOUND);
+      expect(res.json).toHaveBeenCalledWith({
+        Success: false,
+        Status: HttpStatus.NOT_FOUND,
+        Message: 'Subtema no encontrado',
+        Data: mockError.message,
+      });
+    });
+  });
+
+  describe('update', () => {
+    it('Debería actualizar un subtema correctamente', async () => {
+      jest.spyOn(service, 'updateSubtema').mockResolvedValue(mockSubtema as any);
+
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      await controller.update(res as any, mockSubtema._id, mockUpdateSubtemaDto);
+
+      expect(service.updateSubtema).toHaveBeenCalledWith(
+        mockSubtema._id,
+        mockUpdateSubtemaDto,
+      );
+      expect(res.status).toHaveBeenCalledWith(HttpStatus.OK);
+    });
+  });
+
+  describe('delete', () => {
+    it('Debería eliminar un subtema correctamente', async () => {
+      jest.spyOn(service, 'deleteSubtema').mockResolvedValue(mockSubtema as any);
+
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      await controller.delete(res as any, mockSubtema._id);
+
+      expect(service.deleteSubtema).toHaveBeenCalledWith(mockSubtema._id);
+      expect(res.status).toHaveBeenCalledWith(HttpStatus.OK);
+      expect(res.json).toHaveBeenCalledWith({
+        Success: true,
+        Status: HttpStatus.OK,
+        Message: 'Subtema eliminado exitosamente',
+        Data: mockSubtema,
+      });
+    });
+  });
+});

--- a/src/tema/subtema.controller.ts
+++ b/src/tema/subtema.controller.ts
@@ -11,7 +11,7 @@ import {
   Res,
 } from '@nestjs/common';
 import { TemaService } from './tema.service';
-import { TemaDTO, UpdateTemaDTO } from './dto/tema.dto';
+import { CreateSubtemaDTO, UpdateSubtemaDTO } from './dto/subtema.dto';
 import { FilterDto } from '../filters/filters.dto';
 import {
   ApiTags,
@@ -19,161 +19,164 @@ import {
   ApiResponse,
   ApiParam,
   ApiBody,
+  ApiQuery,
 } from '@nestjs/swagger';
 import { ParseObjectIdPipe } from '../pipes/parse-object-id/parse-object-id.pipe';
 
-@ApiTags('tema')
-@Controller('tema')
-export class TemaController {
+@ApiTags('subtema')
+@Controller('subtema')
+export class SubtemaController {
   constructor(private temaService: TemaService) {}
 
   @Post()
-  @ApiOperation({ summary: 'Crear un nuevo tema' })
-  @ApiBody({ type: TemaDTO })
+  @ApiOperation({ summary: 'Crear un nuevo subtema' })
+  @ApiBody({ type: CreateSubtemaDTO })
   @ApiResponse({
     status: 201,
-    description: 'El tema ha sido creado exitosamente.',
-    type: TemaDTO,
+    description: 'El subtema ha sido creado exitosamente.',
   })
   @ApiResponse({ status: 400, description: 'Solicitud incorrecta.' })
-  async post(
+  async create(
     @Res() res,
-    @Body(new ParseObjectIdPipe(['informe_id'])) TemaDTO: TemaDTO,
+    @Body(new ParseObjectIdPipe(['tema_id'])) createSubtemaDTO: CreateSubtemaDTO,
   ) {
     try {
-      const tema = await this.temaService.post(TemaDTO);
+      const tema = await this.temaService.agregarSubtema(
+        createSubtemaDTO.tema_id,
+        createSubtemaDTO,
+      );
       res.status(HttpStatus.CREATED).json({
         Success: true,
         Status: HttpStatus.CREATED,
-        Message: 'Registro Exitoso',
+        Message: 'Subtema creado exitosamente',
         Data: tema,
       });
     } catch (error) {
       res.status(HttpStatus.BAD_REQUEST).json({
         Success: false,
         Status: HttpStatus.BAD_REQUEST,
-        Message:
-          'Error servicio Post: la solicitud contiene un tipo de dato incorrecto o un parametro invalido',
+        Message: 'Error al crear subtema',
         Data: error.message,
       });
     }
   }
 
   @Get()
-  @ApiOperation({ summary: 'Obtener todos los temas' })
+  @ApiOperation({ summary: 'Obtener todos los subtemas' })
+  @ApiQuery({
+    name: 'query',
+    required: false,
+    description: 'Filtros en formato query. Ejemplo: tema_id:507f1f77bcf86cd799439011',
+    example: 'tema_id:507f1f77bcf86cd799439011',
+  })
   @ApiResponse({
     status: 200,
-    description: 'Devuelve todos los temas.',
-    type: [TemaDTO],
+    description: 'Devuelve todos los subtemas filtrados.',
   })
   async getAll(@Res() res, @Query() filterDto: FilterDto) {
     try {
-      const tema = await this.temaService.getAll(filterDto);
-      const counts = await this.temaService.count(filterDto);
+      const subtemas = await this.temaService.getAllSubtemas(filterDto);
+      const counts = await this.temaService.countSubtemas(filterDto);
 
       res.status(HttpStatus.OK).json({
         Success: true,
         Status: HttpStatus.OK,
         Message: 'Peticion Exitosa',
-        Data: tema,
+        Data: subtemas,
         MetaData: { Count: counts },
       });
     } catch (error) {
       res.status(HttpStatus.NOT_FOUND).json({
         Success: false,
         Status: HttpStatus.NOT_FOUND,
-        Message:
-          'Error en servicio GetAll: la peticion contiene un parametro incorrecto o no existe un registro',
+        Message: 'Error al obtener subtemas',
         Data: error.message,
       });
     }
   }
 
   @Get('/:id')
-  @ApiOperation({ summary: 'Obtener un tema por Id' })
-  @ApiParam({ name: 'id', type: 'string' })
+  @ApiOperation({ summary: 'Obtener un subtema por su ID' })
+  @ApiParam({ name: 'id', type: 'string', description: 'ID del subtema' })
   @ApiResponse({
     status: 200,
-    description: 'Devuelve el tema.',
-    type: TemaDTO,
+    description: 'Devuelve el subtema con información del tema padre.',
   })
-  @ApiResponse({ status: 404, description: 'Tema no encontrado.' })
+  @ApiResponse({ status: 404, description: 'Subtema no encontrado.' })
   async getById(@Res() res, @Param('id') id: string) {
     try {
-      const tema = await this.temaService.getById(id);
+      const subtema = await this.temaService.getSubtemaById(id);
       res.status(HttpStatus.OK).json({
         Success: true,
         Status: HttpStatus.OK,
         Message: 'Peticion Exitosa',
-        Data: tema,
+        Data: subtema,
       });
     } catch (error) {
       res.status(HttpStatus.NOT_FOUND).json({
         Success: false,
         Status: HttpStatus.NOT_FOUND,
-        Message:
-          'Error en servicio GetOne: la peticion contiene un parametro incorrecto o no existe un registro',
+        Message: 'Subtema no encontrado',
         Data: error.message,
       });
     }
   }
 
   @Put('/:id')
-  @ApiOperation({ summary: 'Actualizar un tema' })
-  @ApiParam({ name: 'id', type: 'string' })
-  @ApiBody({ type: UpdateTemaDTO })
+  @ApiOperation({ summary: 'Actualizar un subtema por su ID' })
+  @ApiParam({ name: 'id', type: 'string', description: 'ID del subtema' })
+  @ApiBody({ type: UpdateSubtemaDTO })
   @ApiResponse({
     status: 200,
-    description: 'El tema ha sido actualizado exitosamente.',
-    type: TemaDTO,
+    description: 'El subtema ha sido actualizado exitosamente.',
   })
   @ApiResponse({ status: 400, description: 'Solicitud incorrecta.' })
-  @ApiResponse({ status: 404, description: 'Tema no encontrado.' })
-  async put(@Res() res, @Param('id') id: string, @Body() updateTemaDTO: UpdateTemaDTO) {
+  @ApiResponse({ status: 404, description: 'Subtema no encontrado.' })
+  async update(
+    @Res() res,
+    @Param('id') id: string,
+    @Body() updateSubtemaDTO: UpdateSubtemaDTO,
+  ) {
     try {
-      const tema = await this.temaService.put(id, updateTemaDTO);
+      const tema = await this.temaService.updateSubtema(id, updateSubtemaDTO);
       res.status(HttpStatus.OK).json({
         Success: true,
         Status: HttpStatus.OK,
-        Message: 'Actualizacion Exitosa',
+        Message: 'Subtema actualizado exitosamente',
         Data: tema,
       });
     } catch (error) {
       res.status(HttpStatus.BAD_REQUEST).json({
         Success: false,
         Status: HttpStatus.BAD_REQUEST,
-        Message:
-          'Error en servicio Put: la peticion contiene un tipo de dato incorrecto o un parametro invalido',
+        Message: 'Error al actualizar subtema',
         Data: error.message,
       });
     }
   }
 
   @Delete('/:id')
-  @ApiOperation({ summary: 'Eliminar un tema' })
-  @ApiParam({ name: 'id', type: 'string' })
+  @ApiOperation({ summary: 'Eliminar un subtema por su ID' })
+  @ApiParam({ name: 'id', type: 'string', description: 'ID del subtema' })
   @ApiResponse({
     status: 200,
-    description: 'El tema ha sido eliminado exitosamente.',
+    description: 'El subtema ha sido eliminado exitosamente.',
   })
-  @ApiResponse({ status: 404, description: 'Tema no encontrado.' })
+  @ApiResponse({ status: 404, description: 'Subtema no encontrado.' })
   async delete(@Res() res, @Param('id') id: string) {
     try {
-      await this.temaService.delete(id);
+      const tema = await this.temaService.deleteSubtema(id);
       res.status(HttpStatus.OK).json({
         Success: true,
         Status: HttpStatus.OK,
-        Message: 'Eliminacion Exitosa',
-        Data: {
-          _id: id,
-        },
+        Message: 'Subtema eliminado exitosamente',
+        Data: tema,
       });
     } catch (error) {
       res.status(HttpStatus.NOT_FOUND).json({
         Success: false,
         Status: HttpStatus.NOT_FOUND,
-        Message:
-          'Error en el servicio Delete: la peticion contiene parametros incorrectos',
+        Message: 'Error al eliminar subtema',
         Data: error.message,
       });
     }

--- a/src/tema/tema.controller.spec.ts
+++ b/src/tema/tema.controller.spec.ts
@@ -1,8 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { TemaController } from './tema.controller';
 import { TemaDTO } from './dto/tema.dto';
-import { SubtemaDTO } from './dto/subtema.dto';
-import { HallazgoDTO } from './dto/hallazgo.dto';
 import { TemaService } from './tema.service';
 import { HttpStatus } from '@nestjs/common';
 import { FilterDto } from '../filters/filters.dto';
@@ -18,19 +16,6 @@ const mockTemaDto: TemaDTO = {
 const mockTema = {
   ...mockTemaDto,
   _id: '507f1f77bcf86cd799439012',
-};
-
-const mockSubtemaDto: SubtemaDTO = {
-  titulo: 'Archivo General',
-  activo: true,
-  hallazgo: [],
-};
-
-const mockHallazgoDto: HallazgoDTO = {
-  titulo: 'Falta de documentación',
-  criterio: 'Norma ISO 9001',
-  descripcion: 'No se encontró evidencia',
-  activo: true,
 };
 
 describe('TemaController', () => {
@@ -50,12 +35,6 @@ describe('TemaController', () => {
             put: jest.fn(),
             delete: jest.fn(),
             count: jest.fn(),
-            agregarSubtema: jest.fn(),
-            actualizarSubtema: jest.fn(),
-            eliminarSubtema: jest.fn(),
-            agregarHallazgo: jest.fn(),
-            actualizarHallazgo: jest.fn(),
-            eliminarHallazgo: jest.fn(),
           },
         },
       ],
@@ -189,7 +168,7 @@ describe('TemaController', () => {
     it('Debería retornar NotFound con id inválido', async () => {
       jest
         .spyOn(service, 'getById')
-        .mockRejectedValue(new Error(`${mockTema._id} no existe`));
+        .mockRejectedValue(new Error(`Tema ${mockTema._id} no existe`));
 
       const res = {
         status: jest.fn().mockReturnThis(),
@@ -205,7 +184,51 @@ describe('TemaController', () => {
         Status: HttpStatus.NOT_FOUND,
         Message:
           'Error en servicio GetOne: la peticion contiene un parametro incorrecto o no existe un registro',
-        Data: `${mockTema._id} no existe`,
+        Data: `Tema ${mockTema._id} no existe`,
+      });
+    });
+  });
+
+  describe('put', () => {
+    it('Debería actualizar un tema correctamente', async () => {
+      jest.spyOn(service, 'put').mockResolvedValue(mockTemaDto as any);
+
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      await controller.put(res as any, mockTema._id, mockTemaDto);
+
+      expect(service.put).toHaveBeenCalledWith(mockTema._id, mockTemaDto);
+      expect(res.status).toHaveBeenCalledWith(HttpStatus.OK);
+      expect(res.json).toHaveBeenCalledWith({
+        Success: true,
+        Status: HttpStatus.OK,
+        Message: 'Actualizacion Exitosa',
+        Data: mockTemaDto,
+      });
+    });
+
+    it('Debería retornar BadRequest con error', async () => {
+      const mockError = new Error('Validation failed');
+
+      jest.spyOn(service, 'put').mockRejectedValue(mockError);
+
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      await controller.put(res as any, mockTema._id, mockTemaDto);
+
+      expect(res.status).toHaveBeenCalledWith(HttpStatus.BAD_REQUEST);
+      expect(res.json).toHaveBeenCalledWith({
+        Success: false,
+        Status: HttpStatus.BAD_REQUEST,
+        Message:
+          'Error en servicio Put: la peticion contiene un tipo de dato incorrecto o un parametro invalido',
+        Data: mockError.message,
       });
     });
   });
@@ -254,50 +277,6 @@ describe('TemaController', () => {
           'Error en el servicio Delete: la peticion contiene parametros incorrectos',
         Data: mockError.message,
       });
-    });
-  });
-
-  describe('agregarSubtema', () => {
-    it('Debería agregar un subtema correctamente', async () => {
-      jest.spyOn(service, 'agregarSubtema').mockResolvedValue(mockTema as any);
-
-      const res = {
-        status: jest.fn().mockReturnThis(),
-        json: jest.fn(),
-      };
-
-      await controller.agregarSubtema(res as any, mockTema._id, mockSubtemaDto);
-
-      expect(service.agregarSubtema).toHaveBeenCalledWith(
-        mockTema._id,
-        mockSubtemaDto,
-      );
-      expect(res.status).toHaveBeenCalledWith(HttpStatus.CREATED);
-    });
-  });
-
-  describe('agregarHallazgo', () => {
-    it('Debería agregar un hallazgo correctamente', async () => {
-      jest.spyOn(service, 'agregarHallazgo').mockResolvedValue(mockTema as any);
-
-      const res = {
-        status: jest.fn().mockReturnThis(),
-        json: jest.fn(),
-      };
-
-      await controller.agregarHallazgo(
-        res as any,
-        mockTema._id,
-        'sub1',
-        mockHallazgoDto,
-      );
-
-      expect(service.agregarHallazgo).toHaveBeenCalledWith(
-        mockTema._id,
-        'sub1',
-        mockHallazgoDto,
-      );
-      expect(res.status).toHaveBeenCalledWith(HttpStatus.CREATED);
     });
   });
 });

--- a/src/tema/tema.module.ts
+++ b/src/tema/tema.module.ts
@@ -1,5 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TemaController } from './tema.controller';
+import { SubtemaController } from './subtema.controller';
+import { HallazgoController } from './hallazgo.controller';
 import { TemaService } from './tema.service';
 import { MongooseModule } from '@nestjs/mongoose';
 import { Tema, TemaSchema } from './schemas/tema.schema';
@@ -8,7 +10,11 @@ import { Tema, TemaSchema } from './schemas/tema.schema';
   imports: [
     MongooseModule.forFeature([{ name: Tema.name, schema: TemaSchema }]),
   ],
-  controllers: [TemaController],
+  controllers: [
+    TemaController,
+    SubtemaController,
+    HallazgoController,
+  ],
   providers: [TemaService],
   exports: [TemaService],
 })

--- a/src/tema/tema.service.spec.ts
+++ b/src/tema/tema.service.spec.ts
@@ -2,8 +2,8 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { TemaService } from './tema.service';
 import { getModelToken } from '@nestjs/mongoose';
 import { TemaDTO } from './dto/tema.dto';
-import { SubtemaDTO } from './dto/subtema.dto';
-import { HallazgoDTO } from './dto/hallazgo.dto';
+import { CreateSubtemaDTO, UpdateSubtemaDTO } from './dto/subtema.dto';
+import { CreateHallazgoDTO, UpdateHallazgoDTO } from './dto/hallazgo.dto';
 import { Tema } from './schemas/tema.schema';
 import { Model } from 'mongoose';
 import { FilterDto } from '../filters/filters.dto';
@@ -22,17 +22,28 @@ const mockTema = {
   subtema: [],
 };
 
-const mockSubtemaDto: SubtemaDTO = {
+const mockCreateSubtemaDto: CreateSubtemaDTO = {
+  tema_id: '507f1f77bcf86cd799439011',
   titulo: 'Archivo General',
   activo: true,
-  hallazgo: [],
 };
 
-const mockHallazgoDto: HallazgoDTO = {
+const mockUpdateSubtemaDto: UpdateSubtemaDTO = {
+  titulo: 'Archivo General Actualizado'
+};
+
+const mockCreateHallazgoDto: CreateHallazgoDTO = {
+  subtema_id: '507f1f77bcf86cd799439013',
   titulo: 'Falta de documentación',
   criterio: 'Norma ISO 9001',
   descripcion: 'No se encontró evidencia',
   activo: true,
+};
+
+const mockUpdateHallazgoDto: UpdateHallazgoDTO = {
+  titulo: 'Falta de documentación actualizada',
+  criterio: 'Norma ISO 9001',
+  descripcion: 'Descripción actualizada'
 };
 
 describe('TemaService', () => {
@@ -49,6 +60,7 @@ describe('TemaService', () => {
             create: jest.fn(),
             find: jest.fn(),
             findById: jest.fn(),
+            findOne: jest.fn(),
             findByIdAndUpdate: jest.fn(),
             countDocuments: jest.fn(),
           },
@@ -61,7 +73,7 @@ describe('TemaService', () => {
   });
 
   it('Debería estar definido', () => {
-    expect(TemaService).toBeDefined();
+    expect(temaService).toBeDefined();
   });
 
   describe('post', () => {
@@ -74,15 +86,13 @@ describe('TemaService', () => {
       expect(result).toEqual(mockTemaDto);
     });
 
-    it('Debería lanzar un error si el Tema no existe', async () => {
+    it('Debería lanzar un error si el Tema no puede ser creado', async () => {
       jest.spyOn(temaModel, 'create').mockImplementationOnce(() => {
-        throw new Error(
-          `Tema relacionado con id ${mockTemaDto.informe_id} no existe`,
-        );
+        throw new Error('Error al crear tema');
       });
 
       await expect(temaService.post(mockTemaDto)).rejects.toThrow(
-        `Tema relacionado con id ${mockTemaDto.informe_id} no existe`,
+        'Error al crear tema',
       );
     });
   });
@@ -114,6 +124,7 @@ describe('TemaService', () => {
       const mockQuery = {
         sort: jest.fn().mockReturnThis(),
         populate: jest.fn().mockReturnThis(),
+        lean: jest.fn().mockReturnThis(),
         exec: jest.fn().mockResolvedValue(mockTemas),
       };
 
@@ -143,7 +154,7 @@ describe('TemaService', () => {
       } as any);
 
       await expect(temaService.getById(mockTema._id)).rejects.toThrow(
-        `${mockTema._id} no existe`,
+        `Tema ${mockTema._id} no existe`,
       );
 
       expect(temaModel.findById).toHaveBeenCalledWith(mockTema._id);
@@ -172,7 +183,7 @@ describe('TemaService', () => {
       } as any);
 
       await expect(temaService.put(mockTema._id, mockTemaDto)).rejects.toThrow(
-        `${mockTema._id} no existe`,
+        `Tema ${mockTema._id} no existe`,
       );
 
       expect(temaModel.findByIdAndUpdate).toHaveBeenCalledWith(
@@ -200,7 +211,7 @@ describe('TemaService', () => {
       } as any);
 
       await expect(temaService.delete(mockTema._id)).rejects.toThrow(
-        `${mockTema._id} no existe`,
+        `Tema ${mockTema._id} no existe`,
       );
     });
   });
@@ -241,10 +252,10 @@ describe('TemaService', () => {
     it('Debería agregar un subtema al tema', async () => {
       const temaConSubtema = {
         ...mockTema,
-        subtema: [{ ...mockSubtemaDto, _id: 'sub1' }],
+        subtema: [{ ...mockCreateSubtemaDto, _id: 'sub1' }],
         save: jest.fn().mockResolvedValue({
           ...mockTema,
-          subtema: [{ ...mockSubtemaDto, _id: 'sub1' }],
+          subtema: [{ ...mockCreateSubtemaDto, _id: 'sub1' }],
         }),
       };
 
@@ -252,7 +263,7 @@ describe('TemaService', () => {
         exec: jest.fn().mockResolvedValue(temaConSubtema),
       } as any);
 
-      await temaService.agregarSubtema(mockTema._id, mockSubtemaDto);
+      await temaService.agregarSubtema(mockTema._id, mockCreateSubtemaDto);
 
       expect(temaConSubtema.save).toHaveBeenCalled();
     });
@@ -263,16 +274,17 @@ describe('TemaService', () => {
       } as any);
 
       await expect(
-        temaService.agregarSubtema(mockTema._id, mockSubtemaDto),
-      ).rejects.toThrow(`${mockTema._id} no existe`);
+        temaService.agregarSubtema(mockTema._id, mockCreateSubtemaDto),
+      ).rejects.toThrow(`Tema ${mockTema._id} no existe`);
     });
   });
 
-  describe('agregarHallazgo', () => {
-    it('Debería agregar un hallazgo al subtema', async () => {
+  describe('updateSubtema', () => {
+    it('Debería actualizar un subtema', async () => {
       const mockSubtemaConId = {
         _id: 'sub1',
-        ...mockSubtemaDto,
+        titulo: 'Archivo General',
+        activo: true,
         hallazgo: [],
       };
 
@@ -284,23 +296,167 @@ describe('TemaService', () => {
         save: jest.fn().mockResolvedValue(mockTema),
       };
 
-      jest.spyOn(temaModel, 'findById').mockReturnValue({
+      jest.spyOn(temaModel, 'findOne').mockReturnValue({
         exec: jest.fn().mockResolvedValue(temaConSubtema),
       } as any);
 
-      await temaService.agregarHallazgo(mockTema._id, 'sub1', mockHallazgoDto);
+      await temaService.updateSubtema('sub1', mockUpdateSubtemaDto);
 
       expect(temaConSubtema.save).toHaveBeenCalled();
     });
 
-    it('Debería lanzar error si el tema no existe', async () => {
-      jest.spyOn(temaModel, 'findById').mockReturnValue({
+    it('Debería lanzar error si el subtema no existe', async () => {
+      jest.spyOn(temaModel, 'findOne').mockReturnValue({
         exec: jest.fn().mockResolvedValue(null),
       } as any);
 
       await expect(
-        temaService.agregarHallazgo(mockTema._id, 'sub1', mockHallazgoDto),
-      ).rejects.toThrow(`${mockTema._id} no existe`);
+        temaService.updateSubtema('sub1', mockUpdateSubtemaDto),
+      ).rejects.toThrow('Subtema sub1 no existe');
+    });
+  });
+
+  describe('deleteSubtema', () => {
+    it('Debería eliminar un subtema', async () => {
+      const mockSubtemaConId = {
+        _id: 'sub1',
+        titulo: 'Archivo General',
+        activo: true,
+        hallazgo: [],
+      };
+
+      const temaConSubtema = {
+        ...mockTema,
+        subtema: {
+          id: jest.fn().mockReturnValue(mockSubtemaConId),
+        },
+        save: jest.fn().mockResolvedValue(mockTema),
+      };
+
+      jest.spyOn(temaModel, 'findOne').mockReturnValue({
+        exec: jest.fn().mockResolvedValue(temaConSubtema),
+      } as any);
+
+      await temaService.deleteSubtema('sub1');
+
+      expect(temaConSubtema.save).toHaveBeenCalled();
+    });
+  });
+
+  describe('agregarHallazgo', () => {
+    it('Debería agregar un hallazgo al subtema', async () => {
+      const mockSubtemaConId = {
+        _id: 'sub1',
+        titulo: 'Archivo General',
+        activo: true,
+        hallazgo: [],
+      };
+
+      const temaConSubtema = {
+        ...mockTema,
+        subtema: {
+          id: jest.fn().mockReturnValue(mockSubtemaConId),
+        },
+        save: jest.fn().mockResolvedValue(mockTema),
+      };
+
+      jest.spyOn(temaModel, 'findOne').mockReturnValue({
+        exec: jest.fn().mockResolvedValue(temaConSubtema),
+      } as any);
+
+      await temaService.agregarHallazgo('sub1', mockCreateHallazgoDto);
+
+      expect(temaConSubtema.save).toHaveBeenCalled();
+    });
+
+    it('Debería lanzar error si el subtema no existe', async () => {
+      jest.spyOn(temaModel, 'findOne').mockReturnValue({
+        exec: jest.fn().mockResolvedValue(null),
+      } as any);
+
+      await expect(
+        temaService.agregarHallazgo('sub1', mockCreateHallazgoDto),
+      ).rejects.toThrow('Subtema sub1 no existe');
+    });
+  });
+
+  describe('updateHallazgo', () => {
+    it('Debería actualizar un hallazgo', async () => {
+      const mockHallazgoConId = {
+        _id: 'hall1',
+        titulo: 'Falta de documentación',
+        criterio: 'Norma ISO 9001',
+        descripcion: 'No se encontró evidencia',
+        activo: true,
+      };
+
+      const mockSubtemaConId = {
+        _id: 'sub1',
+        titulo: 'Archivo General',
+        activo: true,
+        hallazgo: {
+          id: jest.fn().mockReturnValue(mockHallazgoConId),
+        },
+      };
+
+      const temaConSubtema = {
+        ...mockTema,
+        subtema: [mockSubtemaConId],
+        save: jest.fn().mockResolvedValue(mockTema),
+      };
+
+      jest.spyOn(temaModel, 'findOne').mockReturnValue({
+        exec: jest.fn().mockResolvedValue(temaConSubtema),
+      } as any);
+
+      await temaService.updateHallazgo('hall1', mockUpdateHallazgoDto);
+
+      expect(temaConSubtema.save).toHaveBeenCalled();
+    });
+
+    it('Debería lanzar error si el hallazgo no existe', async () => {
+      jest.spyOn(temaModel, 'findOne').mockReturnValue({
+        exec: jest.fn().mockResolvedValue(null),
+      } as any);
+
+      await expect(
+        temaService.updateHallazgo('hall1', mockUpdateHallazgoDto),
+      ).rejects.toThrow('Hallazgo hall1 no existe');
+    });
+  });
+
+  describe('deleteHallazgo', () => {
+    it('Debería eliminar un hallazgo', async () => {
+      const mockHallazgoConId = {
+        _id: 'hall1',
+        titulo: 'Falta de documentación',
+        criterio: 'Norma ISO 9001',
+        descripcion: 'No se encontró evidencia',
+        activo: true,
+      };
+
+      const mockSubtemaConId = {
+        _id: 'sub1',
+        titulo: 'Archivo General',
+        activo: true,
+        hallazgo: {
+          id: jest.fn().mockReturnValue(mockHallazgoConId),
+        },
+      };
+
+      const temaConSubtema = {
+        ...mockTema,
+        subtema: [mockSubtemaConId],
+        save: jest.fn().mockResolvedValue(mockTema),
+      };
+
+      jest.spyOn(temaModel, 'findOne').mockReturnValue({
+        exec: jest.fn().mockResolvedValue(temaConSubtema),
+      } as any);
+
+      await temaService.deleteHallazgo('hall1');
+
+      expect(temaConSubtema.save).toHaveBeenCalled();
     });
   });
 });

--- a/src/tema/tema.service.ts
+++ b/src/tema/tema.service.ts
@@ -4,9 +4,9 @@ import { Model } from 'mongoose';
 import { FilterDto } from '../filters/filters.dto';
 import { FiltersService } from '../filters/filters.service';
 import { Tema } from './schemas/tema.schema';
-import { TemaDTO } from './dto/tema.dto';
-import { SubtemaDTO } from './dto/subtema.dto';
-import { HallazgoDTO } from './dto/hallazgo.dto';
+import { TemaDTO, UpdateTemaDTO } from './dto/tema.dto';
+import { CreateSubtemaDTO, UpdateSubtemaDTO } from './dto/subtema.dto';
+import { CreateHallazgoDTO, UpdateHallazgoDTO } from './dto/hallazgo.dto';
 
 @Injectable()
 export class TemaService {
@@ -18,6 +18,10 @@ export class TemaService {
   private populateFields(): any[] {
     return [{ path: '' }];
   }
+
+  // ============================================
+  // MÉTODOS CRUD DE TEMA
+  // ============================================
 
   async post(TemaDTO: TemaDTO): Promise<Tema> {
     const fecha = new Date();
@@ -49,20 +53,17 @@ export class TemaService {
   async getById(id: string): Promise<Tema> {
     const tema = await this.TemaModel.findById(id).exec();
     if (!tema) {
-      throw new Error(`${id} no existe`);
+      throw new Error(`Tema ${id} no existe`);
     }
     return tema;
   }
 
-  async put(id: string, TemaDTO: TemaDTO): Promise<Tema> {
-    if (TemaDTO.fecha_creacion) {
-      delete TemaDTO.fecha_creacion;
-    }
-    const update = await this.TemaModel.findByIdAndUpdate(id, TemaDTO, {
+  async put(id: string, updateTemaDTO: UpdateTemaDTO): Promise<Tema> {
+    const update = await this.TemaModel.findByIdAndUpdate(id, updateTemaDTO, {
       new: true,
     }).exec();
     if (!update) {
-      throw new Error(`${id} no existe`);
+      throw new Error(`Tema ${id} no existe`);
     }
     return update;
   }
@@ -74,7 +75,7 @@ export class TemaService {
       { new: true },
     ).exec();
     if (!deleted) {
-      throw new Error(`${id} no existe`);
+      throw new Error(`Tema ${id} no existe`);
     }
     return deleted;
   }
@@ -86,28 +87,104 @@ export class TemaService {
     ).exec();
   }
 
-  async agregarSubtema(temaId: string, SubtemaDTO: SubtemaDTO): Promise<Tema> {
+  // ============================================
+  // MÉTODOS PARA SUBTEMA
+  // ============================================
+
+  async agregarSubtema(temaId: string, createSubtemaDTO: CreateSubtemaDTO): Promise<Tema> {
     const tema = await this.TemaModel.findById(temaId).exec();
     if (!tema) {
-      throw new Error(`${temaId} no existe`);
+      throw new Error(`Tema ${temaId} no existe`);
     }
 
     tema.subtema.push({
-      ...SubtemaDTO,
-      activo: true,
+      titulo: createSubtemaDTO.titulo,
+      activo: createSubtemaDTO.activo ?? true,
       hallazgo: [],
     });
     return await tema.save();
   }
 
-  async actualizarSubtema(
-    temaId: string,
+  async getAllSubtemas(filterDto: FilterDto): Promise<any[]> {
+    const filtersService = new FiltersService(filterDto);
+    const query = filtersService.getQuery();
+    
+    // Extraer tema_id de la query si existe
+    let temaIdFilter = null;
+    if (query && query['tema_id']) {
+      temaIdFilter = query['tema_id'];
+      delete query['tema_id'];
+    }
+
+    // Construir el filtro base
+    const baseFilter: any = {};
+    if (temaIdFilter) {
+      baseFilter._id = temaIdFilter;
+    }
+
+    // Buscar temas que coincidan con el filtro
+    const temas = await this.TemaModel.find(baseFilter).lean().exec();
+
+    // Extraer y aplanar todos los subtemas
+    const allSubtemas = [];
+    for (const tema of temas) {
+      if (tema.subtema && tema.subtema.length > 0) {
+        tema.subtema.forEach((subtema: any) => {
+          if (subtema.activo) {
+            allSubtemas.push({
+              ...subtema,
+              tema: {
+                _id: tema._id,
+                titulo: tema.titulo,
+              },
+            });
+          }
+        });
+      }
+    }
+
+    return allSubtemas;
+  }
+
+  async countSubtemas(filterDto: FilterDto): Promise<number> {
+    const subtemas = await this.getAllSubtemas(filterDto);
+    return subtemas.length;
+  }
+
+  async getSubtemaById(subtemaId: string): Promise<any> {
+    const tema = await this.TemaModel.findOne(
+      { 'subtema._id': subtemaId },
+      { 
+        'subtema.$': 1, 
+        titulo: 1,
+        _id: 1
+      },
+    ).exec();
+
+    if (!tema || !tema.subtema || tema.subtema.length === 0) {
+      throw new Error(`Subtema ${subtemaId} no existe`);
+    }
+
+    // Retornar el subtema con información del tema padre
+    return {
+      ...tema.subtema[0].toObject(),
+      tema: {
+        _id: tema._id,
+        titulo: tema.titulo,
+      },
+    };
+  }
+
+  async updateSubtema(
     subtemaId: string,
-    SubtemaDTO: SubtemaDTO,
+    updateSubtemaDTO: UpdateSubtemaDTO,
   ): Promise<Tema> {
-    const tema = await this.TemaModel.findById(temaId).exec();
+    const tema = await this.TemaModel.findOne({
+      'subtema._id': subtemaId,
+    }).exec();
+
     if (!tema) {
-      throw new Error(`${temaId} no existe`);
+      throw new Error(`Subtema ${subtemaId} no existe`);
     }
 
     const subtema = tema.subtema.id(subtemaId);
@@ -115,18 +192,21 @@ export class TemaService {
       throw new Error(`Subtema ${subtemaId} no existe`);
     }
 
-    subtema.titulo = SubtemaDTO.titulo;
-    if (SubtemaDTO.activo !== undefined) {
-      subtema.activo = SubtemaDTO.activo;
+    // Actualizar solo los campos proporcionados (sin activo)
+    if (updateSubtemaDTO.titulo !== undefined) {
+      subtema.titulo = updateSubtemaDTO.titulo;
     }
 
     return await tema.save();
   }
 
-  async eliminarSubtema(temaId: string, subtemaId: string): Promise<Tema> {
-    const tema = await this.TemaModel.findById(temaId).exec();
+  async deleteSubtema(subtemaId: string): Promise<Tema> {
+    const tema = await this.TemaModel.findOne({
+      'subtema._id': subtemaId,
+    }).exec();
+
     if (!tema) {
-      throw new Error(`${temaId} no existe`);
+      throw new Error(`Subtema ${subtemaId} no existe`);
     }
 
     const subtema = tema.subtema.id(subtemaId);
@@ -135,17 +215,27 @@ export class TemaService {
     }
 
     subtema.activo = false;
+    
+    // También marcar como inactivos todos los hallazgos del subtema
+    subtema.hallazgo.forEach(h => h.activo = false);
+    
     return await tema.save();
   }
 
+  // ============================================
+  // MÉTODOS PARA HALLAZGO
+  // ============================================
+
   async agregarHallazgo(
-    temaId: string,
     subtemaId: string,
-    HallazgoDTO: HallazgoDTO,
+    createHallazgoDTO: CreateHallazgoDTO,
   ): Promise<Tema> {
-    const tema = await this.TemaModel.findById(temaId).exec();
+    const tema = await this.TemaModel.findOne({
+      'subtema._id': subtemaId,
+    }).exec();
+
     if (!tema) {
-      throw new Error(`${temaId} no existe`);
+      throw new Error(`Subtema ${subtemaId} no existe`);
     }
 
     const subtema = tema.subtema.id(subtemaId);
@@ -154,64 +244,169 @@ export class TemaService {
     }
 
     subtema.hallazgo.push({
-      ...HallazgoDTO,
-      activo: true,
+      titulo: createHallazgoDTO.titulo,
+      criterio: createHallazgoDTO.criterio,
+      descripcion: createHallazgoDTO.descripcion,
+      activo: createHallazgoDTO.activo ?? true,
     });
+    
     return await tema.save();
   }
 
-  async actualizarHallazgo(
-    temaId: string,
-    subtemaId: string,
-    hallazgoId: string,
-    HallazgoDTO: HallazgoDTO,
-  ): Promise<Tema> {
-    const tema = await this.TemaModel.findById(temaId).exec();
+  async getAllHallazgos(filterDto: FilterDto): Promise<any[]> {
+    const filtersService = new FiltersService(filterDto);
+    const query = filtersService.getQuery();
+    
+    // Extraer subtema_id de la query si existe
+    let subtemaIdFilter = null;
+    if (query && query['subtema_id']) {
+      subtemaIdFilter = query['subtema_id'];
+      delete query['subtema_id'];
+    }
+
+    // Construir el filtro base
+    const baseFilter: any = {};
+    if (subtemaIdFilter) {
+      baseFilter['subtema._id'] = subtemaIdFilter;
+    }
+
+    // Buscar temas que tengan subtemas
+    const temas = await this.TemaModel.find(baseFilter).lean().exec();
+
+    // Extraer y aplanar todos los hallazgos
+    const allHallazgos = [];
+    for (const tema of temas) {
+      if (tema.subtema && tema.subtema.length > 0) {
+        for (const subtema of tema.subtema) {
+          // Si hay filtro de subtema_id, solo procesar ese subtema
+          if (subtemaIdFilter && subtema._id.toString() !== subtemaIdFilter.toString()) {
+            continue;
+          }
+
+          if (subtema.hallazgo && subtema.hallazgo.length > 0) {
+            subtema.hallazgo.forEach((hallazgo: any) => {
+              if (hallazgo.activo) {
+                allHallazgos.push({
+                  ...hallazgo,
+                  subtema: {
+                    _id: subtema._id,
+                    titulo: subtema.titulo,
+                  },
+                  tema: {
+                    _id: tema._id,
+                    titulo: tema.titulo,
+                  },
+                });
+              }
+            });
+          }
+        }
+      }
+    }
+
+    return allHallazgos;
+  }
+
+  async countHallazgos(filterDto: FilterDto): Promise<number> {
+    const hallazgos = await this.getAllHallazgos(filterDto);
+    return hallazgos.length;
+  }
+
+  async getHallazgoById(hallazgoId: string): Promise<any> {
+    const tema = await this.TemaModel.findOne({
+      'subtema.hallazgo._id': hallazgoId,
+    }).exec();
+
     if (!tema) {
-      throw new Error(`${temaId} no existe`);
-    }
-
-    const subtema = tema.subtema.id(subtemaId);
-    if (!subtema) {
-      throw new Error(`Subtema ${subtemaId} no existe`);
-    }
-
-    const hallazgo = subtema.hallazgo.id(hallazgoId);
-    if (!hallazgo) {
       throw new Error(`Hallazgo ${hallazgoId} no existe`);
     }
 
-    hallazgo.titulo = HallazgoDTO.titulo;
-    hallazgo.criterio = HallazgoDTO.criterio;
-    hallazgo.descripcion = HallazgoDTO.descripcion;
-    if (HallazgoDTO.activo !== undefined) {
-      hallazgo.activo = HallazgoDTO.activo;
+    // Buscar el hallazgo en los subtemas
+    for (const subtema of tema.subtema) {
+      const hallazgo = subtema.hallazgo.id(hallazgoId);
+      if (hallazgo) {
+        return {
+          ...hallazgo.toObject(),
+          subtema: {
+            _id: subtema._id,
+            titulo: subtema.titulo,
+          },
+          tema: {
+            _id: tema._id,
+            titulo: tema.titulo,
+          },
+        };
+      }
+    }
+
+    throw new Error(`Hallazgo ${hallazgoId} no existe`);
+  }
+
+  async updateHallazgo(
+    hallazgoId: string,
+    updateHallazgoDTO: UpdateHallazgoDTO,
+  ): Promise<Tema> {
+    const tema = await this.TemaModel.findOne({
+      'subtema.hallazgo._id': hallazgoId,
+    }).exec();
+
+    if (!tema) {
+      throw new Error(`Hallazgo ${hallazgoId} no existe`);
+    }
+
+    // Buscar el hallazgo en los subtemas
+    let hallazgoEncontrado = null;
+
+    for (const subtema of tema.subtema) {
+      const hallazgo = subtema.hallazgo.id(hallazgoId);
+      if (hallazgo) {
+        hallazgoEncontrado = hallazgo;
+        break;
+      }
+    }
+
+    if (!hallazgoEncontrado) {
+      throw new Error(`Hallazgo ${hallazgoId} no existe`);
+    }
+
+    // Actualizar solo los campos proporcionados (sin activo)
+    if (updateHallazgoDTO.titulo !== undefined) {
+      hallazgoEncontrado.titulo = updateHallazgoDTO.titulo;
+    }
+    if (updateHallazgoDTO.criterio !== undefined) {
+      hallazgoEncontrado.criterio = updateHallazgoDTO.criterio;
+    }
+    if (updateHallazgoDTO.descripcion !== undefined) {
+      hallazgoEncontrado.descripcion = updateHallazgoDTO.descripcion;
     }
 
     return await tema.save();
   }
 
-  async eliminarHallazgo(
-    temaId: string,
-    subtemaId: string,
-    hallazgoId: string,
-  ): Promise<Tema> {
-    const tema = await this.TemaModel.findById(temaId).exec();
+  async deleteHallazgo(hallazgoId: string): Promise<Tema> {
+    const tema = await this.TemaModel.findOne({
+      'subtema.hallazgo._id': hallazgoId,
+    }).exec();
+
     if (!tema) {
-      throw new Error(`${temaId} no existe`);
-    }
-
-    const subtema = tema.subtema.id(subtemaId);
-    if (!subtema) {
-      throw new Error(`Subtema ${subtemaId} no existe`);
-    }
-
-    const hallazgo = subtema.hallazgo.id(hallazgoId);
-    if (!hallazgo) {
       throw new Error(`Hallazgo ${hallazgoId} no existe`);
     }
 
-    hallazgo.activo = false;
+    let hallazgoEncontrado = null;
+
+    for (const subtema of tema.subtema) {
+      const hallazgo = subtema.hallazgo.id(hallazgoId);
+      if (hallazgo) {
+        hallazgoEncontrado = hallazgo;
+        break;
+      }
+    }
+
+    if (!hallazgoEncontrado) {
+      throw new Error(`Hallazgo ${hallazgoId} no existe`);
+    }
+
+    hallazgoEncontrado.activo = false;
     return await tema.save();
   }
 }

--- a/swagger.json
+++ b/swagger.json
@@ -2334,7 +2334,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/TemaDTO"
+                "$ref": "#/components/schemas/UpdateTemaDTO"
               }
             }
           }
@@ -2387,60 +2387,148 @@
         ]
       }
     },
-    "/tema/{temaId}/subtemas": {
+    "/subtema": {
       "post": {
-        "operationId": "TemaController_agregarSubtema",
-        "summary": "Agregar un subtema a un tema",
-        "parameters": [
-          {
-            "name": "temaId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
+        "operationId": "SubtemaController_create",
+        "summary": "Crear un nuevo subtema",
+        "parameters": [],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SubtemaDTO"
+                "$ref": "#/components/schemas/CreateSubtemaDTO"
               }
             }
           }
         },
         "responses": {
           "201": {
-            "description": "El subtema ha sido agregado exitosamente."
+            "description": "El subtema ha sido creado exitosamente."
           },
           "400": {
             "description": "Solicitud incorrecta."
           }
         },
         "tags": [
-          "tema"
+          "subtema"
         ]
-      }
-    },
-    "/tema/{temaId}/subtemas/{subtemaId}": {
-      "put": {
-        "operationId": "TemaController_actualizarSubtema",
-        "summary": "Actualizar un subtema",
+      },
+      "get": {
+        "operationId": "SubtemaController_getAll",
+        "summary": "Obtener todos los subtemas",
         "parameters": [
           {
-            "name": "temaId",
-            "required": true,
-            "in": "path",
+            "name": "query",
+            "required": false,
+            "in": "query",
+            "description": "Filtros en formato query. Ejemplo: tema_id:507f1f77bcf86cd799439011",
+            "schema": {
+              "example": "tema_id:507f1f77bcf86cd799439011",
+              "type": "string"
+            }
+          },
+          {
+            "name": "fields",
+            "required": false,
+            "in": "query",
+            "description": "fields - Fields returned. e.g. col1,col2 …",
             "schema": {
               "type": "string"
             }
           },
           {
-            "name": "subtemaId",
+            "name": "sortby",
+            "required": false,
+            "in": "query",
+            "description": "sortby - Sorted-by fields. e.g. col1,col2 …",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "order",
+            "required": false,
+            "in": "query",
+            "description": "order - Order corresponding to each sortby field, if single value, apply to all sortby fields. e.g. desc,asc …",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "limit - Limit the size of result set. Must be an integer",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "offset",
+            "required": false,
+            "in": "query",
+            "description": "offset - Start position of result set. Must be an integer",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "populate",
+            "required": false,
+            "in": "query",
+            "description": "populate - show subqueries. Must be a boolean",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Devuelve todos los subtemas filtrados."
+          }
+        },
+        "tags": [
+          "subtema"
+        ]
+      }
+    },
+    "/subtema/{id}": {
+      "get": {
+        "operationId": "SubtemaController_getById",
+        "summary": "Obtener un subtema por su ID",
+        "parameters": [
+          {
+            "name": "id",
             "required": true,
             "in": "path",
+            "description": "ID del subtema",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Devuelve el subtema con información del tema padre."
+          },
+          "404": {
+            "description": "Subtema no encontrado."
+          }
+        },
+        "tags": [
+          "subtema"
+        ]
+      },
+      "put": {
+        "operationId": "SubtemaController_update",
+        "summary": "Actualizar un subtema por su ID",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "description": "ID del subtema",
             "schema": {
               "type": "string"
             }
@@ -2451,7 +2539,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SubtemaDTO"
+                "$ref": "#/components/schemas/UpdateSubtemaDTO"
               }
             }
           }
@@ -2459,28 +2547,27 @@
         "responses": {
           "200": {
             "description": "El subtema ha sido actualizado exitosamente."
+          },
+          "400": {
+            "description": "Solicitud incorrecta."
+          },
+          "404": {
+            "description": "Subtema no encontrado."
           }
         },
         "tags": [
-          "tema"
+          "subtema"
         ]
       },
       "delete": {
-        "operationId": "TemaController_eliminarSubtema",
-        "summary": "Eliminar un subtema",
+        "operationId": "SubtemaController_delete",
+        "summary": "Eliminar un subtema por su ID",
         "parameters": [
           {
-            "name": "temaId",
+            "name": "id",
             "required": true,
             "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "subtemaId",
-            "required": true,
-            "in": "path",
+            "description": "ID del subtema",
             "schema": {
               "type": "string"
             }
@@ -2489,83 +2576,158 @@
         "responses": {
           "200": {
             "description": "El subtema ha sido eliminado exitosamente."
+          },
+          "404": {
+            "description": "Subtema no encontrado."
           }
         },
         "tags": [
-          "tema"
+          "subtema"
         ]
       }
     },
-    "/tema/{temaId}/subtemas/{subtemaId}/hallazgos": {
+    "/hallazgo": {
       "post": {
-        "operationId": "TemaController_agregarHallazgo",
-        "summary": "Agregar un hallazgo a un subtema",
-        "parameters": [
-          {
-            "name": "temaId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "subtemaId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
+        "operationId": "HallazgoController_create",
+        "summary": "Crear un nuevo hallazgo",
+        "parameters": [],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/HallazgoDTO"
+                "$ref": "#/components/schemas/CreateHallazgoDTO"
               }
             }
           }
         },
         "responses": {
           "201": {
-            "description": "El hallazgo ha sido agregado exitosamente."
+            "description": "El hallazgo ha sido creado exitosamente."
           },
           "400": {
             "description": "Solicitud incorrecta."
           }
         },
         "tags": [
-          "tema"
+          "hallazgo"
+        ]
+      },
+      "get": {
+        "operationId": "HallazgoController_getAll",
+        "summary": "Obtener todos los hallazgos",
+        "parameters": [
+          {
+            "name": "query",
+            "required": false,
+            "in": "query",
+            "description": "Filtros en formato query. Ejemplo: subtema_id:507f1f77bcf86cd799439011",
+            "schema": {
+              "example": "subtema_id:507f1f77bcf86cd799439011",
+              "type": "string"
+            }
+          },
+          {
+            "name": "fields",
+            "required": false,
+            "in": "query",
+            "description": "fields - Fields returned. e.g. col1,col2 …",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortby",
+            "required": false,
+            "in": "query",
+            "description": "sortby - Sorted-by fields. e.g. col1,col2 …",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "order",
+            "required": false,
+            "in": "query",
+            "description": "order - Order corresponding to each sortby field, if single value, apply to all sortby fields. e.g. desc,asc …",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "limit - Limit the size of result set. Must be an integer",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "offset",
+            "required": false,
+            "in": "query",
+            "description": "offset - Start position of result set. Must be an integer",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "populate",
+            "required": false,
+            "in": "query",
+            "description": "populate - show subqueries. Must be a boolean",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Devuelve todos los hallazgos filtrados."
+          }
+        },
+        "tags": [
+          "hallazgo"
         ]
       }
     },
-    "/tema/{temaId}/subtemas/{subtemaId}/hallazgos/{hallazgoId}": {
-      "put": {
-        "operationId": "TemaController_actualizarHallazgo",
-        "summary": "Actualizar un hallazgo",
+    "/hallazgo/{id}": {
+      "get": {
+        "operationId": "HallazgoController_getById",
+        "summary": "Obtener un hallazgo por su ID",
         "parameters": [
           {
-            "name": "temaId",
+            "name": "id",
             "required": true,
             "in": "path",
+            "description": "ID del hallazgo",
             "schema": {
               "type": "string"
             }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Devuelve el hallazgo con información del subtema y tema padre."
           },
+          "404": {
+            "description": "Hallazgo no encontrado."
+          }
+        },
+        "tags": [
+          "hallazgo"
+        ]
+      },
+      "put": {
+        "operationId": "HallazgoController_update",
+        "summary": "Actualizar un hallazgo por su ID",
+        "parameters": [
           {
-            "name": "subtemaId",
+            "name": "id",
             "required": true,
             "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "hallazgoId",
-            "required": true,
-            "in": "path",
+            "description": "ID del hallazgo",
             "schema": {
               "type": "string"
             }
@@ -2576,7 +2738,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/HallazgoDTO"
+                "$ref": "#/components/schemas/UpdateHallazgoDTO"
               }
             }
           }
@@ -2584,36 +2746,27 @@
         "responses": {
           "200": {
             "description": "El hallazgo ha sido actualizado exitosamente."
+          },
+          "400": {
+            "description": "Solicitud incorrecta."
+          },
+          "404": {
+            "description": "Hallazgo no encontrado."
           }
         },
         "tags": [
-          "tema"
+          "hallazgo"
         ]
       },
       "delete": {
-        "operationId": "TemaController_eliminarHallazgo",
-        "summary": "Eliminar un hallazgo",
+        "operationId": "HallazgoController_delete",
+        "summary": "Eliminar un hallazgo por su ID",
         "parameters": [
           {
-            "name": "temaId",
+            "name": "id",
             "required": true,
             "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "subtemaId",
-            "required": true,
-            "in": "path",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "hallazgoId",
-            "required": true,
-            "in": "path",
+            "description": "ID del hallazgo",
             "schema": {
               "type": "string"
             }
@@ -2622,10 +2775,13 @@
         "responses": {
           "200": {
             "description": "El hallazgo ha sido eliminado exitosamente."
+          },
+          "404": {
+            "description": "Hallazgo no encontrado."
           }
         },
         "tags": [
-          "tema"
+          "hallazgo"
         ]
       }
     },
@@ -3250,13 +3406,16 @@
         "type": "object",
         "properties": {
           "informe_id": {
-            "type": "string"
+            "type": "string",
+            "description": "ID del informe padre"
           },
           "titulo": {
-            "type": "string"
+            "type": "string",
+            "description": "Título del tema"
           },
           "activo": {
-            "type": "boolean"
+            "type": "boolean",
+            "default": true
           },
           "subtema": {
             "type": "array",
@@ -3271,56 +3430,97 @@
         },
         "required": [
           "informe_id",
-          "titulo",
-          "activo",
-          "subtema",
-          "fecha_creacion"
+          "titulo"
         ]
       },
-      "SubtemaDTO": {
+      "UpdateTemaDTO": {
         "type": "object",
         "properties": {
           "titulo": {
-            "type": "string"
+            "type": "string",
+            "description": "Título del tema"
+          }
+        }
+      },
+      "CreateSubtemaDTO": {
+        "type": "object",
+        "properties": {
+          "tema_id": {
+            "type": "string",
+            "description": "ID del tema padre"
+          },
+          "titulo": {
+            "type": "string",
+            "description": "Título del subtema"
           },
           "activo": {
-            "type": "boolean"
-          },
-          "hallazgo": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
+            "type": "boolean",
+            "default": true,
+            "description": "Estado activo del subtema"
           }
         },
         "required": [
-          "titulo",
-          "activo",
-          "hallazgo"
+          "tema_id",
+          "titulo"
         ]
       },
-      "HallazgoDTO": {
+      "UpdateSubtemaDTO": {
         "type": "object",
         "properties": {
           "titulo": {
-            "type": "string"
+            "type": "string",
+            "description": "Título del subtema"
+          }
+        }
+      },
+      "CreateHallazgoDTO": {
+        "type": "object",
+        "properties": {
+          "subtema_id": {
+            "type": "string",
+            "description": "ID del subtema padre"
+          },
+          "titulo": {
+            "type": "string",
+            "description": "Título del hallazgo"
           },
           "criterio": {
-            "type": "string"
+            "type": "string",
+            "description": "Criterio del hallazgo"
           },
           "descripcion": {
-            "type": "string"
+            "type": "string",
+            "description": "Descripción del hallazgo"
           },
           "activo": {
-            "type": "boolean"
+            "type": "boolean",
+            "default": true,
+            "description": "Estado activo del hallazgo"
           }
         },
         "required": [
+          "subtema_id",
           "titulo",
           "criterio",
-          "descripcion",
-          "activo"
+          "descripcion"
         ]
+      },
+      "UpdateHallazgoDTO": {
+        "type": "object",
+        "properties": {
+          "titulo": {
+            "type": "string",
+            "description": "Título del hallazgo"
+          },
+          "criterio": {
+            "type": "string",
+            "description": "Criterio del hallazgo"
+          },
+          "descripcion": {
+            "type": "string",
+            "description": "Descripción del hallazgo"
+          }
+        }
       },
       "CreateAuditoriaGestionDto": {
         "type": "object",


### PR DESCRIPTION
**Resumen de Avances:**

**Refactorización Endpoints Subtema y Hallazgo**
Se ha completado la reestructuración del microservicio CRUD para los módulos de Tema, Subtema y Hallazgo, logrando el desacoplamiento jerárquico de los endpoints y mejorando la arquitectura REST del sistema.

**Cambios Realizados:**

- Reestructuración de Endpoints: Se eliminaron las rutas anidadas complejas. Ahora cada recurso cuenta con rutas independientes (/subtema y /hallazgo), utilizando query params para filtrado por ID jerárquico.
- Optimización de DTOs: Creación de DTOs especializados para creación y actualización. Se implementó la protección del campo activo, restringiendo su modificación exclusivamente a los endpoints de tipo DELETE (Soft Delete).
- Organización de Swagger: Segregación de la documentación en tres controladores independientes (TemaController, SubtemaController, HallazgoController) para facilitar el consumo desde el Frontend.
- Pruebas y Calidad: Actualización de la lógica de tests unitarios con un resultado de 38 pruebas exitosas en 4 suites.

