### PR TITLE
refactor: ajuste de campo destinatario por template y reestructuracion de metadata como listas udistrital/sisifo_documentacion#547

### DIFF
--- a/src/notificacion/dto/notificacion.dto.ts
+++ b/src/notificacion/dto/notificacion.dto.ts
@@ -1,13 +1,26 @@
 import { ApiProperty } from '@nestjs/swagger';
 
 export class NotificacionDTO {
-  @ApiProperty()
-  readonly destinatario: string;
+  @ApiProperty({
+    description: 'Nombre de la plantilla de correo utilizada para el envío',
+    example: 'SISIFO_PLANTILLA_SOLICITUD',
+  })
+  readonly template: string;
 
   @ApiProperty()
   readonly fecha_envio: Date;
 
-  @ApiProperty()
+  @ApiProperty({
+    description:
+      'Metadatos del evento de notificación, incluye destinatarios_to, destinatarios_cc y destinatarios_bcc como listas',
+    example: {
+      tipo_notificacion: 'solicitud_aprobacion_paa',
+      vigencia: '2025',
+      destinatarios_to: ['jefe@udistrital.edu.co'],
+      destinatarios_cc: [],
+      destinatarios_bcc: [],
+    },
+  })
   readonly metadatos: object;
 
   @ApiProperty({

--- a/src/notificacion/notificacion.controller.spec.ts
+++ b/src/notificacion/notificacion.controller.spec.ts
@@ -6,9 +6,15 @@ import { HttpStatus } from '@nestjs/common';
 import { FilterDto } from '../filters/filters.dto';
 
 const mockNotificacionDto: NotificacionDTO = {
-  destinatario: 'usuario@correo.gov.co',
+  template: 'SISIFO_PLANTILLA_SOLICITUD',
   fecha_envio: new Date('2024-06-01T10:00:00Z'),
-  metadatos: { tipo: 'aprobacion_paa' },
+  metadatos: {
+    tipo_notificacion: 'solicitud_aprobacion_paa',
+    vigencia: '2025',
+    destinatarios_to: ['jefe@correo.gov.co'],
+    destinatarios_cc: [],
+    destinatarios_bcc: [],
+  },
   referencia_id: '671aaa8a064222e6583d56e7',
 };
 
@@ -46,12 +52,8 @@ describe('NotificacionController', () => {
       ],
     }).compile();
 
-    controller = module.get<NotificacionController>(
-      NotificacionController,
-    );
-    service = module.get<NotificacionService>(
-      NotificacionService,
-    );
+    controller = module.get<NotificacionController>(NotificacionController);
+    service = module.get<NotificacionService>(NotificacionService);
   });
 
   afterEach(() => {
@@ -64,7 +66,7 @@ describe('NotificacionController', () => {
   });
 
   describe('post', () => {
-    it('Debería crear un  de notificación y retornar CREATED (201) con datos válidos', async () => {
+    it('Debería crear un registro de notificación y retornar CREATED (201) con datos válidos', async () => {
       const serviceSpy = jest
         .spyOn(service, 'post')
         .mockResolvedValue(mockNotificacion as any);
@@ -129,7 +131,7 @@ describe('NotificacionController', () => {
   describe('getAll', () => {
     const mockFilterDto: FilterDto = {
       query: 'activo:true',
-      fields: 'destinatario,fecha_envio',
+      fields: 'template,fecha_envio',
       sortby: 'fecha_creacion',
       order: 'desc',
       limit: '10',
@@ -138,16 +140,8 @@ describe('NotificacionController', () => {
     };
 
     const mockNotificaciones = [
-      {
-        ...mockNotificacion,
-        _id: '1',
-        destinatario: 'user1@correo.gov.co',
-      },
-      {
-        ...mockNotificacion,
-        _id: '2',
-        destinatario: 'user2@correo.gov.co',
-      },
+      { ...mockNotificacion, _id: '1', template: 'SISIFO_PLANTILLA_SOLICITUD' },
+      { ...mockNotificacion, _id: '2', template: 'SISIFO_PLANTILLA_RECHAZO' },
     ];
 
     it('Debería retornar OK (200) con todos los registros y metadata', async () => {
@@ -270,7 +264,7 @@ describe('NotificacionController', () => {
         Success: false,
         Status: HttpStatus.NOT_FOUND,
         Message:
-          'Error en servicio GetOne: la peticion contiene un parametro incorrecto o no existe un ',
+          'Error en servicio GetOne: la peticion contiene un parametro incorrecto o no existe un registro',
         Data: mockError.message,
       });
     });
@@ -279,8 +273,14 @@ describe('NotificacionController', () => {
   describe('put', () => {
     const updateDto: NotificacionDTO = {
       ...mockNotificacionDto,
-      destinatario: 'nuevo@correo.gov.co',
-      metadatos: { tipo: 'aprobacion_programa' },
+      template: 'SISIFO_PLANTILLA_RECHAZO',
+      metadatos: {
+        tipo_notificacion: 'rechazo_paa',
+        vigencia: '2025',
+        destinatarios_to: ['auditor@correo.gov.co'],
+        destinatarios_cc: [],
+        destinatarios_bcc: [],
+      },
       referencia_id: '671aaa8a064222e6583d56e8',
     };
 
@@ -293,10 +293,7 @@ describe('NotificacionController', () => {
 
       await controller.put(res, mockNotificacion._id, updateDto);
 
-      expect(putSpy).toHaveBeenCalledWith(
-        mockNotificacion._id,
-        updateDto,
-      );
+      expect(putSpy).toHaveBeenCalledWith(mockNotificacion._id, updateDto);
       expect(putSpy).toHaveBeenCalledTimes(1);
       expect(res.status).toHaveBeenCalledWith(HttpStatus.OK);
       expect(res.json).toHaveBeenCalledWith({
@@ -314,10 +311,7 @@ describe('NotificacionController', () => {
 
       await controller.put(res, mockNotificacion._id, updateDto);
 
-      expect(putSpy).toHaveBeenCalledWith(
-        mockNotificacion._id,
-        updateDto,
-      );
+      expect(putSpy).toHaveBeenCalledWith(mockNotificacion._id, updateDto);
       expect(res.status).toHaveBeenCalledWith(HttpStatus.BAD_REQUEST);
       expect(res.json).toHaveBeenCalledWith({
         Success: false,
@@ -364,9 +358,7 @@ describe('NotificacionController', () => {
         Success: true,
         Status: HttpStatus.OK,
         Message: 'Eliminacion Exitosa',
-        Data: {
-          _id: mockNotificacion._id,
-        },
+        Data: { _id: mockNotificacion._id },
       });
     });
 

--- a/src/notificacion/notificacion.service.spec.ts
+++ b/src/notificacion/notificacion.service.spec.ts
@@ -7,9 +7,15 @@ import { Model } from 'mongoose';
 import { FilterDto } from '../filters/filters.dto';
 
 const mockNotificacionDto: NotificacionDTO = {
-  destinatario: 'usuario@correo.gov.co',
+  template: 'SISIFO_PLANTILLA_SOLICITUD',
   fecha_envio: new Date('2024-06-01T10:00:00Z'),
-  metadatos: { tipo: 'aprobacion_paa' },
+  metadatos: {
+    tipo_notificacion: 'solicitud_aprobacion_paa',
+    vigencia: '2025',
+    destinatarios_to: ['jefe@correo.gov.co'],
+    destinatarios_cc: [],
+    destinatarios_bcc: [],
+  },
   referencia_id: '671aaa8a064222e6583d56e7',
 };
 
@@ -39,9 +45,7 @@ describe('NotificacionService', () => {
       ],
     }).compile();
 
-    notificacionService = module.get<NotificacionService>(
-      NotificacionService,
-    );
+    notificacionService = module.get<NotificacionService>(NotificacionService);
     notificacionModel = module.get<Model<Notificacion>>(
       getModelToken(Notificacion.name),
     );
@@ -62,9 +66,7 @@ describe('NotificacionService', () => {
         .spyOn(notificacionModel, 'create')
         .mockResolvedValue(mockNotificacion as any);
 
-      const result = await notificacionService.post(
-        mockNotificacionDto,
-      );
+      const result = await notificacionService.post(mockNotificacionDto);
 
       expect(createSpy).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -109,11 +111,37 @@ describe('NotificacionService', () => {
       expect(calledWith.fecha_modificacion).toBeInstanceOf(Date);
     });
 
+    it('Debería almacenar el campo template correctamente', async () => {
+      const createSpy = jest
+        .spyOn(notificacionModel, 'create')
+        .mockResolvedValue(mockNotificacion as any);
+
+      await notificacionService.post(mockNotificacionDto);
+
+      const calledWith = createSpy.mock.calls[0][0] as any;
+      expect(calledWith.template).toBe('SISIFO_PLANTILLA_SOLICITUD');
+      expect(calledWith).not.toHaveProperty('destinatario');
+    });
+
+    it('Debería almacenar los destinatarios como listas dentro de metadatos', async () => {
+      const createSpy = jest
+        .spyOn(notificacionModel, 'create')
+        .mockResolvedValue(mockNotificacion as any);
+
+      await notificacionService.post(mockNotificacionDto);
+
+      const calledWith = createSpy.mock.calls[0][0] as any;
+      expect(calledWith.metadatos).toHaveProperty('destinatarios_to');
+      expect(calledWith.metadatos).toHaveProperty('destinatarios_cc');
+      expect(calledWith.metadatos).toHaveProperty('destinatarios_bcc');
+      expect(Array.isArray(calledWith.metadatos.destinatarios_to)).toBe(true);
+      expect(Array.isArray(calledWith.metadatos.destinatarios_cc)).toBe(true);
+      expect(Array.isArray(calledWith.metadatos.destinatarios_bcc)).toBe(true);
+    });
+
     it('Debería propagar errores de la base de datos', async () => {
       const mockError = new Error('Database error');
-      jest
-        .spyOn(notificacionModel, 'create')
-        .mockRejectedValue(mockError);
+      jest.spyOn(notificacionModel, 'create').mockRejectedValue(mockError);
 
       await expect(
         notificacionService.post(mockNotificacionDto),
@@ -124,7 +152,7 @@ describe('NotificacionService', () => {
   describe('getAll', () => {
     const mockFilterDto: FilterDto = {
       query: 'activo:true',
-      fields: 'destinatario,fecha_envio',
+      fields: 'template,fecha_envio',
       sortby: 'fecha_creacion',
       order: 'desc',
       limit: '10',
@@ -133,16 +161,8 @@ describe('NotificacionService', () => {
     };
 
     const mockNotificaciones = [
-      {
-        ...mockNotificacion,
-        _id: '1',
-        destinatario: 'user1@correo.gov.co',
-      },
-      {
-        ...mockNotificacion,
-        _id: '2',
-        destinatario: 'user2@correo.gov.co',
-      },
+      { ...mockNotificacion, _id: '1', template: 'SISIFO_PLANTILLA_SOLICITUD' },
+      { ...mockNotificacion, _id: '2', template: 'SISIFO_PLANTILLA_RECHAZO' },
     ];
 
     it('Debería retornar todos los registros con filtros aplicados', async () => {
@@ -172,9 +192,7 @@ describe('NotificacionService', () => {
         exec: jest.fn().mockResolvedValue([]),
       };
 
-      jest
-        .spyOn(notificacionModel, 'find')
-        .mockReturnValue(mockQuery as any);
+      jest.spyOn(notificacionModel, 'find').mockReturnValue(mockQuery as any);
 
       const result = await notificacionService.getAll(mockFilterDto);
 
@@ -190,9 +208,7 @@ describe('NotificacionService', () => {
         exec: jest.fn().mockRejectedValue(mockError),
       };
 
-      jest
-        .spyOn(notificacionModel, 'find')
-        .mockReturnValue(mockQuery as any);
+      jest.spyOn(notificacionModel, 'find').mockReturnValue(mockQuery as any);
 
       await expect(
         notificacionService.getAll(mockFilterDto),
@@ -208,9 +224,7 @@ describe('NotificacionService', () => {
           exec: jest.fn().mockResolvedValue(mockNotificacion),
         } as any);
 
-      const result = await notificacionService.getById(
-        mockNotificacion._id,
-      );
+      const result = await notificacionService.getById(mockNotificacion._id);
 
       expect(findByIdSpy).toHaveBeenCalledWith(mockNotificacion._id);
       expect(findByIdSpy).toHaveBeenCalledTimes(1);
@@ -247,16 +261,19 @@ describe('NotificacionService', () => {
   describe('put', () => {
     const updateDto: NotificacionDTO = {
       ...mockNotificacionDto,
-      destinatario: 'nuevo@correo.gov.co',
-      metadatos: { tipo: 'aprobacion_programa' },
+      template: 'SISIFO_PLANTILLA_RECHAZO',
+      metadatos: {
+        tipo_notificacion: 'rechazo_paa',
+        vigencia: '2025',
+        destinatarios_to: ['auditor@correo.gov.co'],
+        destinatarios_cc: [],
+        destinatarios_bcc: [],
+      },
       referencia_id: '671aaa8a064222e6583d56e8',
     };
 
     it('Debería actualizar un registro existente', async () => {
-      const updatedNotificacion = {
-        ...mockNotificacion,
-        ...updateDto,
-      };
+      const updatedNotificacion = { ...mockNotificacion, ...updateDto };
 
       const updateSpy = jest
         .spyOn(notificacionModel, 'findByIdAndUpdate')
@@ -287,10 +304,7 @@ describe('NotificacionService', () => {
           exec: jest.fn().mockResolvedValue(mockNotificacion),
         } as any);
 
-      await notificacionService.put(
-        mockNotificacion._id,
-        updateDto,
-      );
+      await notificacionService.put(mockNotificacion._id, updateDto);
 
       const calledWith = updateSpy.mock.calls[0][1];
       expect(calledWith).not.toHaveProperty('activo');
@@ -306,10 +320,7 @@ describe('NotificacionService', () => {
         } as any);
 
       const dateBefore = new Date();
-      await notificacionService.put(
-        mockNotificacion._id,
-        updateDto,
-      );
+      await notificacionService.put(mockNotificacion._id, updateDto);
       const dateAfter = new Date();
 
       const calledWith = updateSpy.mock.calls[0][1];
@@ -325,11 +336,9 @@ describe('NotificacionService', () => {
     it('Debería lanzar un error si el registro no existe', async () => {
       const nonExistentId = '671aaf35d779a09e092cb999';
 
-      jest
-        .spyOn(notificacionModel, 'findByIdAndUpdate')
-        .mockReturnValue({
-          exec: jest.fn().mockResolvedValue(null),
-        } as any);
+      jest.spyOn(notificacionModel, 'findByIdAndUpdate').mockReturnValue({
+        exec: jest.fn().mockResolvedValue(null),
+      } as any);
 
       await expect(
         notificacionService.put(nonExistentId, updateDto),
@@ -338,27 +347,19 @@ describe('NotificacionService', () => {
 
     it('Debería propagar errores de la base de datos', async () => {
       const mockError = new Error('Database error');
-      jest
-        .spyOn(notificacionModel, 'findByIdAndUpdate')
-        .mockReturnValue({
-          exec: jest.fn().mockRejectedValue(mockError),
-        } as any);
+      jest.spyOn(notificacionModel, 'findByIdAndUpdate').mockReturnValue({
+        exec: jest.fn().mockRejectedValue(mockError),
+      } as any);
 
       await expect(
-        notificacionService.put(
-          mockNotificacion._id,
-          updateDto,
-        ),
+        notificacionService.put(mockNotificacion._id, updateDto),
       ).rejects.toThrow('Database error');
     });
   });
 
   describe('delete', () => {
     it('Debería marcar un registro como inactivo (soft delete)', async () => {
-      const deletedNotificacion = {
-        ...mockNotificacion,
-        activo: false,
-      };
+      const deletedNotificacion = { ...mockNotificacion, activo: false };
 
       const deleteSpy = jest
         .spyOn(notificacionModel, 'findByIdAndUpdate')
@@ -366,9 +367,7 @@ describe('NotificacionService', () => {
           exec: jest.fn().mockResolvedValue(deletedNotificacion),
         } as any);
 
-      const result = await notificacionService.delete(
-        mockNotificacion._id,
-      );
+      const result = await notificacionService.delete(mockNotificacion._id);
 
       expect(deleteSpy).toHaveBeenCalledWith(
         mockNotificacion._id,
@@ -403,11 +402,9 @@ describe('NotificacionService', () => {
     it('Debería propagar errores de la base de datos', async () => {
       const mockError = new Error('Database error during delete');
 
-      jest
-        .spyOn(notificacionModel, 'findByIdAndUpdate')
-        .mockReturnValue({
-          exec: jest.fn().mockRejectedValue(mockError),
-        } as any);
+      jest.spyOn(notificacionModel, 'findByIdAndUpdate').mockReturnValue({
+        exec: jest.fn().mockRejectedValue(mockError),
+      } as any);
 
       await expect(
         notificacionService.delete(mockNotificacion._id),
@@ -462,15 +459,15 @@ describe('NotificacionService', () => {
         exec: jest.fn().mockRejectedValue(mockError),
       } as any);
 
-      await expect(
-        notificacionService.count(filterDto),
-      ).rejects.toThrow('Error al contar documentos');
+      await expect(notificacionService.count(filterDto)).rejects.toThrow(
+        'Error al contar documentos',
+      );
     });
 
     it('Debería aplicar correctamente los filtros del FilterDto', async () => {
       const complexFilterDto: FilterDto = {
-        query: 'activo:true,destinatario:usuario@correo.gov.co',
-        fields: 'destinatario,fecha_envio',
+        query: 'activo:true,template:SISIFO_PLANTILLA_SOLICITUD',
+        fields: 'template,fecha_envio',
         sortby: 'fecha_creacion',
         order: 'desc',
         limit: '10',

--- a/src/notificacion/schema/notificacion.schema.ts
+++ b/src/notificacion/schema/notificacion.schema.ts
@@ -4,7 +4,7 @@ import { Document, Types } from 'mongoose';
 @Schema({ collection: 'notificacion_registro' })
 export class Notificacion extends Document {
   @Prop({ required: false })
-  destinatario: string;
+  template: string;
 
   @Prop({ required: false })
   fecha_envio: Date;

--- a/swagger.json
+++ b/swagger.json
@@ -3625,15 +3625,27 @@
       "NotificacionDTO": {
         "type": "object",
         "properties": {
-          "destinatario": {
-            "type": "string"
+          "template": {
+            "type": "string",
+            "description": "Nombre de la plantilla de correo utilizada para el envío",
+            "example": "SISIFO_PLANTILLA_SOLICITUD"
           },
           "fecha_envio": {
             "format": "date-time",
             "type": "string"
           },
           "metadatos": {
-            "type": "object"
+            "type": "object",
+            "description": "Metadatos del evento de notificación, incluye destinatarios_to, destinatarios_cc y destinatarios_bcc como listas",
+            "example": {
+              "tipo_notificacion": "solicitud_aprobacion_paa",
+              "vigencia": "2025",
+              "destinatarios_to": [
+                "jefe@udistrital.edu.co"
+              ],
+              "destinatarios_cc": [],
+              "destinatarios_bcc": []
+            }
           },
           "referencia_id": {
             "type": "string",
@@ -3642,7 +3654,7 @@
           }
         },
         "required": [
-          "destinatario",
+          "template",
           "fecha_envio",
           "metadatos",
           "referencia_id"


### PR DESCRIPTION
# Descripcion
Refactorizacion del modelo de datos para el registro de notificaciones. Se migra la persistencia de un esquema de multiples registros por destinatario a un unico registro por evento, sustituyendo el campo destinatario por template y gestionando los destinatarios como listas dentro de la metadata.

## Cambios realizados
* **Modelo (notificacion.schema.ts):**
    * Eliminacion del campo destinatario (string).
    * Inclusion del campo template (string). El campo metadatos permanece como objeto para soportar el nuevo esquema de listas.
* **DTO (notificacion.dto.ts):**
    * Sustitucion de destinatario por template.
    * Actualizacion de @ApiProperty en metadatos para documentar explicitamente las tres listas de destinatarios: destinatarios_to, destinatarios_cc y destinatarios_bcc.
* **Pruebas Unitarias:**
    * Actualizacion de mocks en notificacion.controller.spec.ts y notificacion.service.spec.ts.
    * Implementacion de casos de prueba en el service spec para verificar la persistencia correcta del campo template, la ausencia del campo antiguo y la validacion de los tres campos de destinatarios como arreglos (arrays) dentro de metadatos.