### PR TITLE
feat: implementar auditoria padre

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,6 +14,7 @@ import { InformeModule } from './informe/informe.module';
 import { TemaModule } from './tema/tema.module';
 import { AuditoriaGestionModule } from './auditoria-gestion/auditoria-gestion.module';
 import { NotificacionModule } from './notificacion/notificacion.module';
+import { AuditoriaPadreModule } from './auditoria-padre/auditoria-padre.module';
 
 @Module({
   imports: [
@@ -40,6 +41,7 @@ import { NotificacionModule } from './notificacion/notificacion.module';
     TemaModule,
     AuditoriaGestionModule,
     NotificacionModule,
+    AuditoriaPadreModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/auditoria-estado/auditoria-estado.service.spec.ts
+++ b/src/auditoria-estado/auditoria-estado.service.spec.ts
@@ -54,6 +54,7 @@ describe('EstadoAuditoriaService', () => {
           provide: getModelToken(Auditoria.name),
           useValue: {
             findById: jest.fn(),
+            findByIdAndUpdate: jest.fn().mockReturnValue({ exec: jest.fn().mockResolvedValue(mockAuditoria) }),
           },
         },
       ],

--- a/src/auditoria-gestion/auditoria-gestion.controller.spec.ts
+++ b/src/auditoria-gestion/auditoria-gestion.controller.spec.ts
@@ -38,6 +38,7 @@ const mockCreateAuditoriaGestionDto: CreateAuditoriaGestionDto = {
   activo: true,
   fecha_creacion: new Date('2024-01-01'),
   fecha_modificacion: new Date('2024-01-01'),
+  auditoria_padre_id: '67297dda3416d2a85e5d6d90',
   // Datos de Estado (auditoria_id se crea automáticamente, no se envía en POST)
   auditoria_id: undefined,
   usuario_id: 76767,

--- a/src/auditoria-gestion/auditoria-gestion.service.spec.ts
+++ b/src/auditoria-gestion/auditoria-gestion.service.spec.ts
@@ -35,6 +35,7 @@ const mockCreateAuditoriaGestionDto: CreateAuditoriaGestionDto = {
   activo: true,
   fecha_creacion: new Date('2024-01-01'),
   fecha_modificacion: new Date('2024-01-01'),
+  auditoria_padre_id: '67297dda3416d2a85e5d6d90',
   // Datos de Estado (auditoria_id se genera automáticamente)
   auditoria_id: undefined,
   usuario_id: 76767,

--- a/src/auditoria-gestion/dto/create-auditoria-gestion.dto.ts
+++ b/src/auditoria-gestion/dto/create-auditoria-gestion.dto.ts
@@ -11,6 +11,9 @@ export class CreateAuditoriaGestionDto implements CreateAuditoriaGestion {
   readonly plan_auditoria_id: string;
 
   @ApiProperty()
+  readonly auditoria_padre_id: string;
+
+  @ApiProperty()
   readonly titulo: string;
 
   @ApiProperty()

--- a/src/auditoria-gestion/dto/create-auditoria-gestion.dto.ts
+++ b/src/auditoria-gestion/dto/create-auditoria-gestion.dto.ts
@@ -11,7 +11,7 @@ export class CreateAuditoriaGestionDto implements CreateAuditoriaGestion {
   readonly plan_auditoria_id: string;
 
   @ApiProperty()
-  readonly auditoria_padre_id: string;
+  readonly auditoria_padre_id?: string;
 
   @ApiProperty()
   readonly titulo: string;

--- a/src/auditoria-padre/auditoria-padre.controller.spec.ts
+++ b/src/auditoria-padre/auditoria-padre.controller.spec.ts
@@ -1,0 +1,218 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuditoriaPadreService } from './auditoria-padre.service';
+import { HttpStatus } from '@nestjs/common';
+import { AuditoriaPadreDTO } from './dto/auditoria-padre.dto';
+import { FilterDto } from '../filters/filters.dto';
+
+// Mock del ParseObjectIdPipe usando ruta relativa
+jest.mock('../pipes/parse-object-id/parse-object-id.pipe');
+
+// Importar el controlador después del mock
+import { AuditoriaPadreController } from './auditoria-padre.controller';
+
+const mockAuditoriaPadreDTO: AuditoriaPadreDTO = {
+  plan_auditoria_id: '67197dda3416d2a85e5d6d8f',
+  titulo: 'Auditoría Padre 2024',
+  tipo_evaluacion_id: 1,
+  cronograma_actividad: [],
+  estado_id: 1,
+  vigencia_id: 2024,
+  macroproceso_id: 10,
+  proceso_id: 20,
+  dependencia_id: 30,
+  auditorias: [],
+  activo: true,
+  fecha_creacion: new Date('2024-01-01'),
+  fecha_modificacion: new Date('2024-01-01'),
+};
+
+const mockAuditoriaPadre = {
+  ...mockAuditoriaPadreDTO,
+  _id: '671aa963064222e6583d56e4',
+};
+
+describe('AuditoriaPadreController', () => {
+  let auditoriaPadreController: AuditoriaPadreController;
+  let auditoriaPadreService: AuditoriaPadreService;
+
+  const mockAuditoriaPadreService = {
+    post: jest.fn(),
+    getAll: jest.fn(),
+    getById: jest.fn(),
+    put: jest.fn(),
+    delete: jest.fn(),
+    count: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AuditoriaPadreController],
+      providers: [
+        {
+          provide: AuditoriaPadreService,
+          useValue: mockAuditoriaPadreService,
+        },
+      ],
+    }).compile();
+
+    auditoriaPadreController = module.get<AuditoriaPadreController>(
+      AuditoriaPadreController,
+    );
+    auditoriaPadreService = module.get<AuditoriaPadreService>(
+      AuditoriaPadreService,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('Debería estar definido', () => {
+    expect(auditoriaPadreController).toBeDefined();
+  });
+
+  describe('post', () => {
+    it('Debería crear una auditoria padre exitosamente', async () => {
+      const mockRes = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      mockAuditoriaPadreService.post.mockResolvedValue(mockAuditoriaPadre);
+
+      await auditoriaPadreController.post(mockRes as any, mockAuditoriaPadreDTO);
+
+      expect(mockRes.status).toHaveBeenCalledWith(HttpStatus.CREATED);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        Success: true,
+        Status: HttpStatus.CREATED,
+        Message: 'Registro Exitoso',
+        Data: mockAuditoriaPadre,
+      });
+    });
+
+    it('Debería retornar BAD_REQUEST si el servicio lanza un error', async () => {
+      const mockRes = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      mockAuditoriaPadreService.post.mockRejectedValue(
+        new Error('Error al crear'),
+      );
+
+      await auditoriaPadreController.post(mockRes as any, mockAuditoriaPadreDTO);
+
+      expect(mockRes.status).toHaveBeenCalledWith(HttpStatus.BAD_REQUEST);
+    });
+  });
+
+  describe('getAll', () => {
+    it('Debería retornar todas las auditorias padre', async () => {
+      const mockRes = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+      const filterDto: FilterDto = {} as FilterDto;
+
+      mockAuditoriaPadreService.getAll.mockResolvedValue([mockAuditoriaPadre]);
+      mockAuditoriaPadreService.count.mockResolvedValue(1);
+
+      await auditoriaPadreController.getAll(mockRes as any, filterDto);
+
+      expect(mockRes.status).toHaveBeenCalledWith(HttpStatus.OK);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        Success: true,
+        Status: HttpStatus.OK,
+        Message: 'Peticion Exitosa',
+        Data: [mockAuditoriaPadre],
+        MetaData: { Count: 1 },
+      });
+    });
+  });
+
+  describe('getById', () => {
+    it('Debería retornar una auditoria padre por id', async () => {
+      const mockRes = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      mockAuditoriaPadreService.getById.mockResolvedValue(mockAuditoriaPadre);
+
+      await auditoriaPadreController.getById(mockRes as any, mockAuditoriaPadre._id);
+
+      expect(mockRes.status).toHaveBeenCalledWith(HttpStatus.OK);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        Success: true,
+        Status: HttpStatus.OK,
+        Message: 'Peticion Exitosa',
+        Data: mockAuditoriaPadre,
+      });
+    });
+
+    it('Debería retornar NOT_FOUND si no existe', async () => {
+      const mockRes = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      mockAuditoriaPadreService.getById.mockRejectedValue(
+        new Error('no existe'),
+      );
+
+      await auditoriaPadreController.getById(mockRes as any, 'id-invalido');
+
+      expect(mockRes.status).toHaveBeenCalledWith(HttpStatus.NOT_FOUND);
+    });
+  });
+
+  describe('put', () => {
+    it('Debería actualizar una auditoria padre exitosamente', async () => {
+      const mockRes = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      mockAuditoriaPadreService.put.mockResolvedValue(mockAuditoriaPadre);
+
+      await auditoriaPadreController.put(
+        mockRes as any,
+        mockAuditoriaPadre._id,
+        mockAuditoriaPadreDTO,
+      );
+
+      expect(mockRes.status).toHaveBeenCalledWith(HttpStatus.OK);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        Success: true,
+        Status: HttpStatus.OK,
+        Message: 'Actualizacion Exitosa',
+        Data: mockAuditoriaPadre,
+      });
+    });
+  });
+
+  describe('delete', () => {
+    it('Debería eliminar una auditoria padre exitosamente', async () => {
+      const mockRes = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      mockAuditoriaPadreService.delete.mockResolvedValue({
+        ...mockAuditoriaPadre,
+        activo: false,
+      });
+
+      await auditoriaPadreController.delete(mockRes as any, mockAuditoriaPadre._id);
+
+      expect(mockRes.status).toHaveBeenCalledWith(HttpStatus.OK);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        Success: true,
+        Status: HttpStatus.OK,
+        Message: 'Eliminacion Exitosa',
+        Data: { _id: mockAuditoriaPadre._id },
+      });
+    });
+  });
+});

--- a/src/auditoria-padre/auditoria-padre.controller.ts
+++ b/src/auditoria-padre/auditoria-padre.controller.ts
@@ -1,0 +1,191 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpStatus,
+  Param,
+  Post,
+  Put,
+  Query,
+  Res,
+} from '@nestjs/common';
+import { AuditoriaPadreService } from './auditoria-padre.service';
+import { AuditoriaPadreDTO } from './dto/auditoria-padre.dto';
+import { FilterDto } from '../filters/filters.dto';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiBody,
+} from '@nestjs/swagger';
+import { ParseObjectIdPipe } from '../pipes/parse-object-id/parse-object-id.pipe';
+
+@ApiTags('auditoria-padre')
+@Controller('auditoria-padre')
+export class AuditoriaPadreController {
+  constructor(private AuditoriaPadreService: AuditoriaPadreService) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Crear una nueva auditoria padre' })
+  @ApiBody({ type: AuditoriaPadreDTO })
+  @ApiResponse({
+    status: 201,
+    description: 'La auditoria padre ha sido creada exitosamente.',
+    type: AuditoriaPadreDTO,
+  })
+  @ApiResponse({ status: 400, description: 'Solicitud incorrecta.' })
+  async post(
+    @Res() res,
+    @Body(new ParseObjectIdPipe(['plan_auditoria_id']))
+    auditoriaPadreDTO: AuditoriaPadreDTO,
+  ) {
+    try {
+      const auditoriaPadre =
+        await this.AuditoriaPadreService.post(auditoriaPadreDTO);
+      res.status(HttpStatus.CREATED).json({
+        Success: true,
+        Status: HttpStatus.CREATED,
+        Message: 'Registro Exitoso',
+        Data: auditoriaPadre,
+      });
+    } catch (error) {
+      res.status(HttpStatus.BAD_REQUEST).json({
+        Success: false,
+        Status: HttpStatus.BAD_REQUEST,
+        Message:
+          'Error servicio Post: la solicitud contiene un tipo de dato incorrecto o un parametro invalido',
+        Data: error.message,
+      });
+    }
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'Obtener todas las auditorias padre' })
+  @ApiResponse({
+    status: 200,
+    description: 'Devuelve todas las auditorias padre.',
+    type: [AuditoriaPadreDTO],
+  })
+  async getAll(@Res() res, @Query() filterDto: FilterDto) {
+    try {
+      const auditoriasPadre =
+        await this.AuditoriaPadreService.getAll(filterDto);
+      const counts = await this.AuditoriaPadreService.count(filterDto);
+
+      res.status(HttpStatus.OK).json({
+        Success: true,
+        Status: HttpStatus.OK,
+        Message: 'Peticion Exitosa',
+        Data: auditoriasPadre,
+        MetaData: { Count: counts },
+      });
+    } catch (error) {
+      res.status(HttpStatus.NOT_FOUND).json({
+        Success: false,
+        Status: HttpStatus.NOT_FOUND,
+        Message:
+          'Error en servicio GetAll: la peticion contiene un parametro incorrecto o no existe un registro',
+        Data: error.message,
+      });
+    }
+  }
+
+  @Get('/:id')
+  @ApiOperation({ summary: 'Obtener una auditoria padre por Id' })
+  @ApiParam({ name: 'id', type: 'string' })
+  @ApiResponse({
+    status: 200,
+    description: 'Devuelve la auditoria padre.',
+    type: AuditoriaPadreDTO,
+  })
+  @ApiResponse({ status: 404, description: 'Auditoria padre no encontrada.' })
+  async getById(@Res() res, @Param('id') id: string) {
+    try {
+      const auditoriaPadre = await this.AuditoriaPadreService.getById(id);
+      res.status(HttpStatus.OK).json({
+        Success: true,
+        Status: HttpStatus.OK,
+        Message: 'Peticion Exitosa',
+        Data: auditoriaPadre,
+      });
+    } catch (error) {
+      res.status(HttpStatus.NOT_FOUND).json({
+        Success: false,
+        Status: HttpStatus.NOT_FOUND,
+        Message:
+          'Error en servicio GetOne: la peticion contiene un parametro incorrecto o no existe un registro',
+        Data: error.message,
+      });
+    }
+  }
+
+  @Put('/:id')
+  @ApiOperation({ summary: 'Actualizar una auditoria padre' })
+  @ApiParam({ name: 'id', type: 'string' })
+  @ApiBody({ type: AuditoriaPadreDTO })
+  @ApiResponse({
+    status: 200,
+    description: 'La auditoria padre ha sido actualizada exitosamente.',
+    type: AuditoriaPadreDTO,
+  })
+  @ApiResponse({ status: 400, description: 'Solicitud incorrecta.' })
+  @ApiResponse({ status: 404, description: 'Auditoria padre no encontrada.' })
+  async put(
+    @Res() res,
+    @Param('id') id: string,
+    @Body() auditoriaPadreDTO: AuditoriaPadreDTO,
+  ) {
+    try {
+      const auditoriaPadre = await this.AuditoriaPadreService.put(
+        id,
+        auditoriaPadreDTO,
+      );
+      res.status(HttpStatus.OK).json({
+        Success: true,
+        Status: HttpStatus.OK,
+        Message: 'Actualizacion Exitosa',
+        Data: auditoriaPadre,
+      });
+    } catch (error) {
+      res.status(HttpStatus.BAD_REQUEST).json({
+        Success: false,
+        Status: HttpStatus.BAD_REQUEST,
+        Message:
+          'Error en servicio Put: la peticion contiene un tipo de dato incorrecto o un parametro invalido',
+        Data: error.message,
+      });
+    }
+  }
+
+  @Delete('/:id')
+  @ApiOperation({ summary: 'Eliminar una auditoria padre' })
+  @ApiParam({ name: 'id', type: 'string' })
+  @ApiResponse({
+    status: 200,
+    description: 'La auditoria padre ha sido eliminada exitosamente.',
+  })
+  @ApiResponse({ status: 404, description: 'Auditoria padre no encontrada.' })
+  async delete(@Res() res, @Param('id') id: string) {
+    try {
+      await this.AuditoriaPadreService.delete(id);
+      res.status(HttpStatus.OK).json({
+        Success: true,
+        Status: HttpStatus.OK,
+        Message: 'Eliminacion Exitosa',
+        Data: {
+          _id: id,
+        },
+      });
+    } catch (error) {
+      res.status(HttpStatus.NOT_FOUND).json({
+        Success: false,
+        Status: HttpStatus.NOT_FOUND,
+        Message:
+          'Error en el servicio Delete: la peticion contiene parametros incorrectos',
+        Data: error.message,
+      });
+    }
+  }
+}

--- a/src/auditoria-padre/auditoria-padre.module.ts
+++ b/src/auditoria-padre/auditoria-padre.module.ts
@@ -1,0 +1,25 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { AuditoriaPadreController } from './auditoria-padre.controller';
+import { AuditoriaPadreService } from './auditoria-padre.service';
+import {
+  AuditoriaPadre,
+  AuditoriaPadreSchema,
+} from './schemas/auditoria-padre.schema';
+import {
+  PlanAuditoria,
+  PlanAuditoriaSchema,
+} from 'src/plan-auditoria/schemas/plan-auditoria.schema';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: AuditoriaPadre.name, schema: AuditoriaPadreSchema },
+      { name: PlanAuditoria.name, schema: PlanAuditoriaSchema },
+    ]),
+  ],
+  controllers: [AuditoriaPadreController],
+  providers: [AuditoriaPadreService],
+  exports: [AuditoriaPadreService],
+})
+export class AuditoriaPadreModule {}

--- a/src/auditoria-padre/auditoria-padre.service.spec.ts
+++ b/src/auditoria-padre/auditoria-padre.service.spec.ts
@@ -1,0 +1,224 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuditoriaPadreService } from './auditoria-padre.service';
+import { getModelToken } from '@nestjs/mongoose';
+import { AuditoriaPadre } from './schemas/auditoria-padre.schema';
+import { AuditoriaPadreDTO } from './dto/auditoria-padre.dto';
+import { PlanAuditoria } from '../plan-auditoria/schemas/plan-auditoria.schema';
+import { Model } from 'mongoose';
+import { FilterDto } from '../filters/filters.dto';
+
+const mockAuditoriaPadreDTO: AuditoriaPadreDTO = {
+  plan_auditoria_id: '67197dda3416d2a85e5d6d8f',
+  titulo: 'Auditoría Padre 2024',
+  tipo_evaluacion_id: 1,
+  cronograma_actividad: [],
+  estado_id: 1,
+  vigencia_id: 2024,
+  macroproceso_id: 10,
+  proceso_id: 20,
+  dependencia_id: 30,
+  auditorias: [],
+  activo: true,
+  fecha_creacion: new Date('2024-01-01'),
+  fecha_modificacion: new Date('2024-01-01'),
+};
+
+const mockAuditoriaPadre = {
+  ...mockAuditoriaPadreDTO,
+  _id: '671aa963064222e6583d56e4',
+};
+
+const mockPlanAuditoria = {
+  _id: '67197dda3416d2a85e5d6d8f',
+  nombre: 'Plan Anual de Auditoría 2024',
+};
+
+describe('AuditoriaPadreService', () => {
+  let auditoriaPadreService: AuditoriaPadreService;
+  let auditoriaPadreModel: Model<AuditoriaPadre>;
+  let planAuditoriaModel: Model<PlanAuditoria>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuditoriaPadreService,
+        {
+          provide: getModelToken(AuditoriaPadre.name),
+          useValue: {
+            create: jest.fn(),
+            find: jest.fn(),
+            findById: jest.fn(),
+            findByIdAndUpdate: jest.fn(),
+            countDocuments: jest.fn(),
+          },
+        },
+        {
+          provide: getModelToken(PlanAuditoria.name),
+          useValue: {
+            findById: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    auditoriaPadreService = module.get<AuditoriaPadreService>(
+      AuditoriaPadreService,
+    );
+    auditoriaPadreModel = module.get<Model<AuditoriaPadre>>(
+      getModelToken(AuditoriaPadre.name),
+    );
+    planAuditoriaModel = module.get<Model<PlanAuditoria>>(
+      getModelToken(PlanAuditoria.name),
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('Debería estar definido', () => {
+    expect(auditoriaPadreService).toBeDefined();
+    expect(auditoriaPadreModel).toBeDefined();
+    expect(planAuditoriaModel).toBeDefined();
+  });
+
+  describe('post', () => {
+    it('Debería crear y devolver una auditoria padre cuando los datos son válidos', async () => {
+      jest.spyOn(planAuditoriaModel, 'findById').mockReturnValue({
+        exec: jest.fn().mockResolvedValue(mockPlanAuditoria),
+      } as any);
+
+      jest
+        .spyOn(auditoriaPadreModel, 'create')
+        .mockResolvedValue(mockAuditoriaPadre as any);
+
+      const result = await auditoriaPadreService.post(mockAuditoriaPadreDTO);
+
+      expect(result).toEqual(mockAuditoriaPadre);
+    });
+
+    it('Debería lanzar un error si el PlanAuditoria no existe', async () => {
+      jest.spyOn(planAuditoriaModel, 'findById').mockReturnValue({
+        exec: jest.fn().mockResolvedValue(null),
+      } as any);
+
+      await expect(
+        auditoriaPadreService.post(mockAuditoriaPadreDTO),
+      ).rejects.toThrow(
+        `Plan auditoria relacionada con id ${mockAuditoriaPadreDTO.plan_auditoria_id} no existe`,
+      );
+    });
+  });
+
+  describe('getAll', () => {
+    it('Debería retornar todas las auditorias padre', async () => {
+      const filterDto: FilterDto = {} as FilterDto;
+      jest.spyOn(auditoriaPadreModel, 'find').mockReturnValue({
+        sort: jest.fn().mockReturnThis(),
+        populate: jest.fn().mockReturnThis(),
+        lean: jest.fn().mockReturnThis(),
+        exec: jest.fn().mockResolvedValue([mockAuditoriaPadre]),
+      } as any);
+
+      jest.spyOn(auditoriaPadreModel, 'countDocuments').mockReturnValue({
+        exec: jest.fn().mockResolvedValue(1),
+      } as any);
+
+      const result = await auditoriaPadreService.getAll(filterDto);
+
+      expect(result).toEqual([mockAuditoriaPadre]);
+    });
+  });
+
+  describe('getById', () => {
+    it('Debería retornar una auditoria padre por id', async () => {
+      jest.spyOn(auditoriaPadreModel, 'findById').mockReturnValue({
+        exec: jest.fn().mockResolvedValue(mockAuditoriaPadre),
+      } as any);
+
+      const result = await auditoriaPadreService.getById(
+        mockAuditoriaPadre._id,
+      );
+
+      expect(result).toEqual(mockAuditoriaPadre);
+    });
+
+    it('Debería lanzar un error si la auditoria padre no existe', async () => {
+      jest.spyOn(auditoriaPadreModel, 'findById').mockReturnValue({
+        exec: jest.fn().mockResolvedValue(null),
+      } as any);
+
+      await expect(
+        auditoriaPadreService.getById(mockAuditoriaPadre._id),
+      ).rejects.toThrow(`${mockAuditoriaPadre._id} no existe`);
+    });
+  });
+
+  describe('put', () => {
+    it('Debería actualizar y retornar una auditoria padre', async () => {
+      jest.spyOn(planAuditoriaModel, 'findById').mockReturnValue({
+        exec: jest.fn().mockResolvedValue(mockPlanAuditoria),
+      } as any);
+
+      jest.spyOn(auditoriaPadreModel, 'findByIdAndUpdate').mockReturnValue({
+        exec: jest.fn().mockResolvedValue(mockAuditoriaPadre),
+      } as any);
+
+      const result = await auditoriaPadreService.put(
+        mockAuditoriaPadre._id,
+        mockAuditoriaPadreDTO,
+      );
+
+      expect(result).toEqual(mockAuditoriaPadre);
+    });
+
+    it('Debería lanzar un error si la auditoria padre no existe al actualizar', async () => {
+      jest.spyOn(planAuditoriaModel, 'findById').mockReturnValue({
+        exec: jest.fn().mockResolvedValue(mockPlanAuditoria),
+      } as any);
+
+      jest.spyOn(auditoriaPadreModel, 'findByIdAndUpdate').mockReturnValue({
+        exec: jest.fn().mockResolvedValue(null),
+      } as any);
+
+      await expect(
+        auditoriaPadreService.put(mockAuditoriaPadre._id, mockAuditoriaPadreDTO),
+      ).rejects.toThrow(`${mockAuditoriaPadre._id} no existe`);
+    });
+  });
+
+  describe('delete', () => {
+    it('Debería desactivar y retornar una auditoria padre', async () => {
+      jest.spyOn(auditoriaPadreModel, 'findByIdAndUpdate').mockReturnValue({
+        exec: jest.fn().mockResolvedValue({ ...mockAuditoriaPadre, activo: false }),
+      } as any);
+
+      const result = await auditoriaPadreService.delete(mockAuditoriaPadre._id);
+
+      expect(result).toEqual({ ...mockAuditoriaPadre, activo: false });
+    });
+
+    it('Debería lanzar un error si la auditoria padre no existe al eliminar', async () => {
+      jest.spyOn(auditoriaPadreModel, 'findByIdAndUpdate').mockReturnValue({
+        exec: jest.fn().mockResolvedValue(null),
+      } as any);
+
+      await expect(
+        auditoriaPadreService.delete(mockAuditoriaPadre._id),
+      ).rejects.toThrow(`${mockAuditoriaPadre._id} no existe`);
+    });
+  });
+
+  describe('count', () => {
+    it('Debería retornar el conteo de auditorias padre', async () => {
+      const filterDto: FilterDto = {} as FilterDto;
+      jest.spyOn(auditoriaPadreModel, 'countDocuments').mockReturnValue({
+        exec: jest.fn().mockResolvedValue(5),
+      } as any);
+
+      const result = await auditoriaPadreService.count(filterDto);
+
+      expect(result).toBe(5);
+    });
+  });
+});

--- a/src/auditoria-padre/auditoria-padre.service.ts
+++ b/src/auditoria-padre/auditoria-padre.service.ts
@@ -1,0 +1,111 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { FilterDto } from '../filters/filters.dto';
+import { FiltersService } from '../filters/filters.service';
+import { AuditoriaPadre } from './schemas/auditoria-padre.schema';
+import { AuditoriaPadreDTO } from './dto/auditoria-padre.dto';
+import { PlanAuditoria } from '../plan-auditoria/schemas/plan-auditoria.schema';
+
+@Injectable()
+export class AuditoriaPadreService {
+  constructor(
+    @InjectModel(AuditoriaPadre.name)
+    private readonly AuditoriaPadreModel: Model<AuditoriaPadre>,
+    @InjectModel(PlanAuditoria.name)
+    private readonly PlanAuditoriaModel: Model<PlanAuditoria>,
+  ) {}
+
+  private populateFields(): any[] {
+    return [{ path: 'plan_auditoria_id' }];
+  }
+
+  private async checkRelated(auditoriaPadreDTO: AuditoriaPadreDTO) {
+    if (auditoriaPadreDTO.plan_auditoria_id) {
+      const planAuditoria = await this.PlanAuditoriaModel.findById(
+        auditoriaPadreDTO.plan_auditoria_id,
+      ).exec();
+      if (!planAuditoria) {
+        throw new Error(
+          `Plan auditoria relacionada con id ${auditoriaPadreDTO.plan_auditoria_id} no existe`,
+        );
+      }
+    }
+  }
+
+  async post(auditoriaPadreDTO: AuditoriaPadreDTO): Promise<AuditoriaPadre> {
+    const fecha = new Date();
+    const auditoriaPadreData = {
+      ...auditoriaPadreDTO,
+      activo: true,
+      fecha_creacion: fecha,
+      fecha_modificacion: fecha,
+    };
+    await this.checkRelated(auditoriaPadreDTO);
+    return await this.AuditoriaPadreModel.create(auditoriaPadreData);
+  }
+
+  async getAll(filterDto: FilterDto): Promise<AuditoriaPadre[]> {
+    const filtersService = new FiltersService(filterDto);
+    let populateFields = [];
+    if (filtersService.isPopulated()) {
+      populateFields = this.populateFields();
+    }
+    return (await this.AuditoriaPadreModel.find(
+      filtersService.getQuery(),
+      filtersService.getFields() as any,
+      filtersService.getLimitAndOffset(),
+    )
+      .sort(filtersService.getSortBy())
+      .populate(populateFields)
+      .lean()
+      .exec()) as unknown as AuditoriaPadre[];
+  }
+
+  async getById(id: string): Promise<AuditoriaPadre> {
+    const auditoriaPadre = await this.AuditoriaPadreModel.findById(id).exec();
+    if (!auditoriaPadre) {
+      throw new Error(`${id} no existe`);
+    }
+    return auditoriaPadre;
+  }
+
+  async put(
+    id: string,
+    auditoriaPadreDTO: AuditoriaPadreDTO,
+  ): Promise<AuditoriaPadre> {
+    auditoriaPadreDTO.fecha_modificacion = new Date();
+    if (auditoriaPadreDTO.fecha_creacion) {
+      delete auditoriaPadreDTO.fecha_creacion;
+    }
+    await this.checkRelated(auditoriaPadreDTO);
+    const update = await this.AuditoriaPadreModel.findByIdAndUpdate(
+      id,
+      auditoriaPadreDTO,
+      { new: true },
+    ).exec();
+    if (!update) {
+      throw new Error(`${id} no existe`);
+    }
+    return update;
+  }
+
+  async delete(id: string): Promise<AuditoriaPadre> {
+    const deleted = await this.AuditoriaPadreModel.findByIdAndUpdate(
+      id,
+      { activo: false },
+      { new: true },
+    ).exec();
+    if (!deleted) {
+      throw new Error(`${id} no existe`);
+    }
+    return deleted;
+  }
+
+  async count(filterDto: FilterDto): Promise<number> {
+    const filtersService = new FiltersService(filterDto);
+    return await this.AuditoriaPadreModel.countDocuments(
+      filtersService.getQuery(),
+    ).exec();
+  }
+}

--- a/src/auditoria-padre/dto/auditoria-padre.dto.ts
+++ b/src/auditoria-padre/dto/auditoria-padre.dto.ts
@@ -1,0 +1,42 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AuditoriaPadreDTO {
+  @ApiProperty()
+  readonly plan_auditoria_id: string;
+
+  @ApiProperty()
+  readonly titulo: string;
+
+  @ApiProperty()
+  readonly tipo_evaluacion_id: number;
+
+  @ApiProperty()
+  readonly cronograma_actividad: string[] = [];
+
+  @ApiProperty()
+  readonly estado_id: number;
+
+  @ApiProperty()
+  readonly vigencia_id: number;
+
+  @ApiProperty()
+  readonly macroproceso_id: number;
+
+  @ApiProperty()
+  readonly proceso_id: number;
+
+  @ApiProperty()
+  readonly dependencia_id: number;
+
+  @ApiProperty()
+  readonly auditorias: string[] = [];
+
+  @ApiProperty()
+  activo: boolean;
+
+  @ApiProperty()
+  fecha_creacion: Date;
+
+  @ApiProperty()
+  fecha_modificacion: Date;
+}

--- a/src/auditoria-padre/schemas/auditoria-padre.schema.ts
+++ b/src/auditoria-padre/schemas/auditoria-padre.schema.ts
@@ -1,0 +1,48 @@
+import { Schema, Prop, SchemaFactory } from '@nestjs/mongoose';
+import { Document, Types } from 'mongoose';
+import { PlanAuditoria } from '../../plan-auditoria/schemas/plan-auditoria.schema';
+
+@Schema({ collection: 'auditoria_padre' })
+export class AuditoriaPadre extends Document {
+  @Prop({ required: false, type: Types.ObjectId, ref: PlanAuditoria.name })
+  plan_auditoria_id: PlanAuditoria | Types.ObjectId;
+
+  @Prop({ required: false })
+  titulo: string;
+
+  @Prop({ required: false })
+  tipo_evaluacion_id: number;
+
+  @Prop({ type: [{ type: String }], required: false })
+  cronograma_actividad: string[];
+
+  @Prop({ required: false })
+  estado_id: number;
+
+  @Prop({ required: false })
+  vigencia_id: number;
+
+  @Prop({ required: false })
+  macroproceso_id: number;
+
+  @Prop({ required: false })
+  proceso_id: number;
+
+  @Prop({ required: false })
+  dependencia_id: number;
+
+  @Prop({ type: [{ type: String }], required: false })
+  auditorias: string[];
+
+  @Prop({ required: false })
+  activo: boolean;
+
+  @Prop({ required: false })
+  fecha_creacion: Date;
+
+  @Prop({ required: false })
+  fecha_modificacion: Date;
+}
+
+export const AuditoriaPadreSchema = SchemaFactory.createForClass(AuditoriaPadre);
+AuditoriaPadreSchema.set('versionKey', false);

--- a/src/auditoria/auditoria.controller.spec.ts
+++ b/src/auditoria/auditoria.controller.spec.ts
@@ -14,6 +14,7 @@ const mockAuditoriaDTO: AuditoriaDTO = {
   titulo: 'Auditoría General 2024',
   tipo_evaluacion_id: 2,
   plan_auditoria_id: '67197dda3416d2a85e5d6d8f',
+  auditoria_padre_id: '67297dda3416d2a85e5d6d90',
   cronograma_id: [1, 2, 3],
   estado_id: 3,
   no_auditoria: 123420,

--- a/src/auditoria/auditoria.controller.ts
+++ b/src/auditoria/auditoria.controller.ts
@@ -38,7 +38,8 @@ export class AuditoriaController {
   @ApiResponse({ status: 400, description: 'Solicitud incorrecta.' })
   async post(
     @Res() res,
-    @Body(new ParseObjectIdPipe(['plan_auditoria_id']))
+    // TODO: eliminar 'plan_auditoria_id' de este pipe cuando la migración a auditoria_padre esté completa
+    @Body(new ParseObjectIdPipe(['plan_auditoria_id', 'auditoria_padre_id']))
     AuditoriaDTO: AuditoriaDTO,
   ) {
     try {

--- a/src/auditoria/auditoria.module.ts
+++ b/src/auditoria/auditoria.module.ts
@@ -11,11 +11,16 @@ import {
   Auditor,
   AuditorSchema,
 } from '../auditoria-auditor/schemas/auditor.schema';
+import {
+  AuditoriaPadre,
+  AuditoriaPadreSchema
+} from 'src/auditoria-padre/schemas/auditoria-padre.schema';
 @Module({
   imports: [
     MongooseModule.forFeature([
       { name: Auditoria.name, schema: AuditoriaSchema },
       { name: PlanAuditoria.name, schema: PlanAuditoriaSchema },
+      { name: AuditoriaPadre.name, schema: AuditoriaPadreSchema },
       { name: Auditor.name, schema: AuditorSchema },
     ]),
   ],

--- a/src/auditoria/auditoria.service.spec.ts
+++ b/src/auditoria/auditoria.service.spec.ts
@@ -4,13 +4,16 @@ import { getModelToken } from '@nestjs/mongoose';
 import { Auditoria } from './schemas/auditoria.schema';
 import { AuditoriaDTO } from './dto/auditoria.dto';
 import { PlanAuditoria } from '../plan-auditoria/schemas/plan-auditoria.schema';
+import { AuditoriaPadre } from '../auditoria-padre/schemas/auditoria-padre.schema';
 import { Model } from 'mongoose';
 import { FilterDto } from '../filters/filters.dto';
+import { Auditor } from '../auditoria-auditor/schemas/auditor.schema';
 
 const mockAuditoriaDTO: AuditoriaDTO = {
   titulo: 'Auditoría General 2024',
   tipo_evaluacion_id: 2,
   plan_auditoria_id: '67197dda3416d2a85e5d6d8f',
+  auditoria_padre_id: '67297dda3416d2a85e5d6d90',
   cronograma_id: [1, 2, 3],
   estado_id: 3,
   no_auditoria: 123420,
@@ -50,6 +53,8 @@ describe('AuditoriaService', () => {
   let auditoriaService: AuditoriaService;
   let auditoriaModel: Model<Auditoria>;
   let planAuditoriaModel: Model<PlanAuditoria>;
+  let auditoriaPadreModel: Model<AuditoriaPadre>;
+  let auditorModel: Model<Auditor>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -71,6 +76,21 @@ describe('AuditoriaService', () => {
             findById: jest.fn(),
           },
         },
+        {
+          provide: getModelToken(Auditor.name),
+          useValue: {
+            find: jest.fn(),
+            select: jest.fn(),
+            lean: jest.fn(),
+            exec: jest.fn(),
+          },
+        },
+        {
+          provide: getModelToken(AuditoriaPadre.name),
+          useValue: {
+            findById: jest.fn().mockReturnValue({ exec: jest.fn().mockResolvedValue({ _id: '67297dda3416d2a85e5d6d90' }) }),
+          },
+        },
       ],
     }).compile();
 
@@ -81,6 +101,10 @@ describe('AuditoriaService', () => {
     planAuditoriaModel = module.get<Model<PlanAuditoria>>(
       getModelToken(PlanAuditoria.name),
     );
+    auditoriaPadreModel = module.get<Model<AuditoriaPadre>>(
+      getModelToken(AuditoriaPadre.name),
+    );
+    auditorModel = module.get<Model<Auditor>>(getModelToken(Auditor.name));
   });
 
   afterEach(() => {
@@ -101,6 +125,10 @@ describe('AuditoriaService', () => {
           exec: jest.fn().mockResolvedValue(mockPlanAuditoria),
         } as any);
 
+      const auditoriaPadreFindSpy = jest
+        .spyOn(auditoriaPadreModel, 'findById')
+        .mockReturnValue({ exec: jest.fn().mockResolvedValue({ _id: mockAuditoriaDTO.auditoria_padre_id }) } as any);
+
       const createSpy = jest
         .spyOn(auditoriaModel, 'create')
         .mockResolvedValue(mockAuditoria as any);
@@ -109,6 +137,9 @@ describe('AuditoriaService', () => {
 
       expect(planAuditoriaFindSpy).toHaveBeenCalledWith(
         mockAuditoriaDTO.plan_auditoria_id,
+      );
+      expect(auditoriaPadreFindSpy).toHaveBeenCalledWith(
+        mockAuditoriaDTO.auditoria_padre_id,
       );
       expect(createSpy).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -142,6 +173,7 @@ describe('AuditoriaService', () => {
       const dtoSinPlanAuditoria = {
         ...mockAuditoriaDTO,
         plan_auditoria_id: undefined,
+        auditoria_padre_id: undefined,
       };
       const createSpy = jest
         .spyOn(auditoriaModel, 'create')
@@ -235,6 +267,7 @@ describe('AuditoriaService', () => {
 
       expect(mockQuery.populate).toHaveBeenCalledWith([
         { path: 'plan_auditoria_id' },
+        { path: 'auditoria_padre_id' },
       ]);
     });
 

--- a/src/auditoria/auditoria.service.spec.ts
+++ b/src/auditoria/auditoria.service.spec.ts
@@ -205,6 +205,25 @@ describe('AuditoriaService', () => {
         }),
       );
     });
+
+    it('Debería lanzar un error si la auditoria padre relacionada no existe (post)', async () => {
+      jest.spyOn(planAuditoriaModel, 'findById').mockReturnValue({
+        exec: jest.fn().mockResolvedValue(mockPlanAuditoria),
+      } as any);
+
+      jest.spyOn(auditoriaPadreModel, 'findById').mockReturnValue({
+        exec: jest.fn().mockResolvedValue(null),
+      } as any);
+
+      await expect(auditoriaService.post(mockAuditoriaDTO)).rejects.toThrow(
+        `Auditoria padre relacionada con id ${mockAuditoriaDTO.auditoria_padre_id} no existe`,
+      );
+
+      expect(auditoriaPadreModel.findById).toHaveBeenCalledWith(
+        mockAuditoriaDTO.auditoria_padre_id,
+      );
+      expect(auditoriaModel.create).not.toHaveBeenCalled();
+    });
   });
 
   describe('getAll', () => {
@@ -502,6 +521,27 @@ describe('AuditoriaService', () => {
       expect(calledWith.fecha_modificacion.getTime()).toBeLessThanOrEqual(
         dateAfter.getTime(),
       );
+    });
+
+    it('Debería lanzar un error si la auditoria padre relacionada no existe (put)', async () => {
+      jest.spyOn(planAuditoriaModel, 'findById').mockReturnValue({
+        exec: jest.fn().mockResolvedValue(mockPlanAuditoria),
+      } as any);
+
+      jest.spyOn(auditoriaPadreModel, 'findById').mockReturnValue({
+        exec: jest.fn().mockResolvedValue(null),
+      } as any);
+
+      await expect(
+        auditoriaService.put(mockAuditoria._id, updateDto),
+      ).rejects.toThrow(
+        `Auditoria padre relacionada con id ${updateDto.auditoria_padre_id} no existe`,
+      );
+
+      expect(auditoriaPadreModel.findById).toHaveBeenCalledWith(
+        updateDto.auditoria_padre_id,
+      );
+      expect(auditoriaModel.findByIdAndUpdate).not.toHaveBeenCalled();
     });
   });
 

--- a/src/auditoria/auditoria.service.ts
+++ b/src/auditoria/auditoria.service.ts
@@ -38,13 +38,13 @@ export class AuditoriaService {
       }
     }
     // Validar relación con auditoria_padre si viene provista
-    if ((AuditoriaDTO as any).auditoria_padre_id) {
+    if (AuditoriaDTO.auditoria_padre_id) {
       const padre = await this.AuditoriaPadreModel.findById(
-        (AuditoriaDTO as any).auditoria_padre_id,
+        AuditoriaDTO.auditoria_padre_id,
       ).exec();
       if (!padre) {
         throw new Error(
-          `Auditoria padre relacionada con id ${(AuditoriaDTO as any).auditoria_padre_id} no existe`,
+          `Auditoria padre relacionada con id ${AuditoriaDTO.auditoria_padre_id} no existe`,
         );
       }
     }

--- a/src/auditoria/auditoria.service.ts
+++ b/src/auditoria/auditoria.service.ts
@@ -7,6 +7,7 @@ import { Auditoria } from './schemas/auditoria.schema';
 import { AuditoriaDTO } from './dto/auditoria.dto';
 import { PlanAuditoria } from '../plan-auditoria/schemas/plan-auditoria.schema';
 import { Auditor } from '../auditoria-auditor/schemas/auditor.schema';
+import { AuditoriaPadre } from '../auditoria-padre/schemas/auditoria-padre.schema';
 @Injectable()
 export class AuditoriaService {
   constructor(
@@ -14,15 +15,18 @@ export class AuditoriaService {
     private readonly AuditoriaModel: Model<Auditoria>,
     @InjectModel(PlanAuditoria.name)
     private readonly PlanAuditoriaModel: Model<PlanAuditoria>,
+    @InjectModel(AuditoriaPadre.name)
+    private readonly AuditoriaPadreModel: Model<AuditoriaPadre>,
     @InjectModel(Auditor.name)
     private readonly AuditorModel: Model<Auditor>,
   ) {}
 
   private populateFields(): any[] {
-    return [{ path: 'plan_auditoria_id' }];
+    return [{ path: 'plan_auditoria_id' }, { path: 'auditoria_padre_id' }];
   }
 
   private async checkRelated(AuditoriaDTO: AuditoriaDTO) {
+    // TODO: eliminar la validación por `plan_auditoria_id` cuando la migración a `auditoria_padre_id` esté completa
     if (AuditoriaDTO.plan_auditoria_id) {
       const planAuditoria = await this.PlanAuditoriaModel.findById(
         AuditoriaDTO.plan_auditoria_id,
@@ -30,6 +34,17 @@ export class AuditoriaService {
       if (!planAuditoria) {
         throw new Error(
           `Plan auditoria relacionada con id ${AuditoriaDTO.plan_auditoria_id} no existe`,
+        );
+      }
+    }
+    // Validar relación con auditoria_padre si viene provista
+    if ((AuditoriaDTO as any).auditoria_padre_id) {
+      const padre = await this.AuditoriaPadreModel.findById(
+        (AuditoriaDTO as any).auditoria_padre_id,
+      ).exec();
+      if (!padre) {
+        throw new Error(
+          `Auditoria padre relacionada con id ${(AuditoriaDTO as any).auditoria_padre_id} no existe`,
         );
       }
     }

--- a/src/auditoria/dto/auditoria.dto.ts
+++ b/src/auditoria/dto/auditoria.dto.ts
@@ -3,6 +3,8 @@ import { ApiProperty } from '@nestjs/swagger';
 export class AuditoriaDTO {
   @ApiProperty()
   readonly plan_auditoria_id: string;
+  @ApiProperty()
+  readonly auditoria_padre_id: string;
 
   @ApiProperty()
   readonly titulo: string;

--- a/src/auditoria/dto/auditoria.dto.ts
+++ b/src/auditoria/dto/auditoria.dto.ts
@@ -2,9 +2,9 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class AuditoriaDTO {
   @ApiProperty()
-  readonly plan_auditoria_id: string;
+  readonly plan_auditoria_id?: string;
   @ApiProperty()
-  readonly auditoria_padre_id: string;
+  readonly auditoria_padre_id?: string;
 
   @ApiProperty()
   readonly titulo: string;

--- a/src/auditoria/schemas/auditoria.schema.ts
+++ b/src/auditoria/schemas/auditoria.schema.ts
@@ -1,11 +1,16 @@
 import { Schema, Prop, SchemaFactory } from '@nestjs/mongoose';
 import { Document, Types } from 'mongoose';
 import { PlanAuditoria } from '../../plan-auditoria/schemas/plan-auditoria.schema';
+import { AuditoriaPadre } from '../../auditoria-padre/schemas/auditoria-padre.schema';
 
 @Schema({ collection: 'auditoria' })
 export class Auditoria extends Document {
+  // TODO: Migración: eliminar `plan_auditoria_id` cuando la transición a `auditoria_padre_id` esté completa
   @Prop({ required: false, type: Types.ObjectId, ref: PlanAuditoria.name })
   plan_auditoria_id: PlanAuditoria | Types.ObjectId;
+
+  @Prop({ required: false, type: Types.ObjectId, ref: AuditoriaPadre.name })
+  auditoria_padre_id: AuditoriaPadre | Types.ObjectId;
 
   @Prop({ required: false })
   titulo: string;

--- a/swagger.json
+++ b/swagger.json
@@ -2880,6 +2880,232 @@
           "notificacion"
         ]
       }
+    },
+    "/auditoria-padre": {
+      "post": {
+        "operationId": "AuditoriaPadreController_post",
+        "summary": "Crear una nueva auditoria padre",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AuditoriaPadreDTO"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "La auditoria padre ha sido creada exitosamente.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuditoriaPadreDTO"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Solicitud incorrecta."
+          }
+        },
+        "tags": [
+          "auditoria-padre"
+        ]
+      },
+      "get": {
+        "operationId": "AuditoriaPadreController_getAll",
+        "summary": "Obtener todas las auditorias padre",
+        "parameters": [
+          {
+            "name": "query",
+            "required": false,
+            "in": "query",
+            "description": " query-Filter.e.g.col1:v1,col2:v2… ",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "fields",
+            "required": false,
+            "in": "query",
+            "description": "fields - Fields returned. e.g. col1,col2 …",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortby",
+            "required": false,
+            "in": "query",
+            "description": "sortby - Sorted-by fields. e.g. col1,col2 …",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "order",
+            "required": false,
+            "in": "query",
+            "description": "order - Order corresponding to each sortby field, if single value, apply to all sortby fields. e.g. desc,asc …",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "in": "query",
+            "description": "limit - Limit the size of result set. Must be an integer",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "offset",
+            "required": false,
+            "in": "query",
+            "description": "offset - Start position of result set. Must be an integer",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "populate",
+            "required": false,
+            "in": "query",
+            "description": "populate - show subqueries. Must be a boolean",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Devuelve todas las auditorias padre.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AuditoriaPadreDTO"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "auditoria-padre"
+        ]
+      }
+    },
+    "/auditoria-padre/{id}": {
+      "get": {
+        "operationId": "AuditoriaPadreController_getById",
+        "summary": "Obtener una auditoria padre por Id",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Devuelve la auditoria padre.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuditoriaPadreDTO"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Auditoria padre no encontrada."
+          }
+        },
+        "tags": [
+          "auditoria-padre"
+        ]
+      },
+      "put": {
+        "operationId": "AuditoriaPadreController_put",
+        "summary": "Actualizar una auditoria padre",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AuditoriaPadreDTO"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "La auditoria padre ha sido actualizada exitosamente.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuditoriaPadreDTO"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Solicitud incorrecta."
+          },
+          "404": {
+            "description": "Auditoria padre no encontrada."
+          }
+        },
+        "tags": [
+          "auditoria-padre"
+        ]
+      },
+      "delete": {
+        "operationId": "AuditoriaPadreController_delete",
+        "summary": "Eliminar una auditoria padre",
+        "parameters": [
+          {
+            "name": "id",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "La auditoria padre ha sido eliminada exitosamente."
+          },
+          "404": {
+            "description": "Auditoria padre no encontrada."
+          }
+        },
+        "tags": [
+          "auditoria-padre"
+        ]
+      }
     }
   },
   "info": {
@@ -3658,6 +3884,73 @@
           "fecha_envio",
           "metadatos",
           "referencia_id"
+        ]
+      },
+      "AuditoriaPadreDTO": {
+        "type": "object",
+        "properties": {
+          "plan_auditoria_id": {
+            "type": "string"
+          },
+          "titulo": {
+            "type": "string"
+          },
+          "tipo_evaluacion_id": {
+            "type": "number"
+          },
+          "cronograma_actividad": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "estado_id": {
+            "type": "number"
+          },
+          "vigencia_id": {
+            "type": "number"
+          },
+          "macroproceso_id": {
+            "type": "number"
+          },
+          "proceso_id": {
+            "type": "number"
+          },
+          "dependencia_id": {
+            "type": "number"
+          },
+          "auditorias": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "activo": {
+            "type": "boolean"
+          },
+          "fecha_creacion": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "fecha_modificacion": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "required": [
+          "plan_auditoria_id",
+          "titulo",
+          "tipo_evaluacion_id",
+          "cronograma_actividad",
+          "estado_id",
+          "vigencia_id",
+          "macroproceso_id",
+          "proceso_id",
+          "dependencia_id",
+          "auditorias",
+          "activo",
+          "fecha_creacion",
+          "fecha_modificacion"
         ]
       }
     }

--- a/swagger.json
+++ b/swagger.json
@@ -3192,6 +3192,9 @@
           "plan_auditoria_id": {
             "type": "string"
           },
+          "auditoria_padre_id": {
+            "type": "string"
+          },
           "titulo": {
             "type": "string"
           },
@@ -3274,6 +3277,7 @@
         },
         "required": [
           "plan_auditoria_id",
+          "auditoria_padre_id",
           "titulo",
           "tipo_evaluacion_id",
           "cronograma_id",
@@ -3711,6 +3715,9 @@
           "plan_auditoria_id": {
             "type": "string"
           },
+          "auditoria_padre_id": {
+            "type": "string"
+          },
           "titulo": {
             "type": "string"
           },
@@ -3815,6 +3822,7 @@
         },
         "required": [
           "plan_auditoria_id",
+          "auditoria_padre_id",
           "titulo",
           "tipo_evaluacion_id",
           "cronograma_id",


### PR DESCRIPTION
This pull request introduces a new "AuditoriaPadre" (Parent Audit) feature to the codebase, including its module, controller, service, and related tests. It also integrates this new feature into the main application module and updates related DTOs and tests to support the new relationships. The changes are primarily focused on enabling CRUD operations for "AuditoriaPadre" entities and ensuring their integration with existing audit management functionality.

- Answers to udistrital/sisifo_documentacion#557

**Major changes introduced:**

### AuditoriaPadre Feature Implementation

* Added the new `AuditoriaPadreModule`, including its controller (`AuditoriaPadreController`), service (`AuditoriaPadreService`), and Mongoose schema integration. This enables full CRUD operations for "AuditoriaPadre" entities, including validation, filtering, and error handling. [[1]](diffhunk://#diff-db02c333d13770b56e80c99fde6a2266634450ef6160bf7df216377152219263R1-R25) [[2]](diffhunk://#diff-d60c8e0dac7d90b0c52eb0f7fed98a92cc2de42fe1a1dda6c556c7510aaa3c10R1-R191)
* Implemented comprehensive unit tests for both the controller and service of "AuditoriaPadre", covering all CRUD operations and error scenarios. [[1]](diffhunk://#diff-3e0ef345f03126c7c1e117af5a74b7966345f4d4dd438bc165c182d3e06c4dacR1-R218) [[2]](diffhunk://#diff-f7ba5afe574ebc45431b5bb31baeb680b76c87e87fe417102cdac1ac96899dc9R1-R224)

### Application Integration

* Registered the new `AuditoriaPadreModule` in the main application module (`app.module.ts`) to make its functionality available throughout the application. [[1]](diffhunk://#diff-089f4f2474b64391c42b6e66aed33977e132058d92108f0a63234a7862e1f8b8R17) [[2]](diffhunk://#diff-089f4f2474b64391c42b6e66aed33977e132058d92108f0a63234a7862e1f8b8R44)

### DTO and Relationship Updates

* Updated the `CreateAuditoriaGestionDto` to include a new `auditoria_padre_id` property, establishing a relationship between "AuditoriaGestion" and "AuditoriaPadre".
* Updated test mocks in `auditoria-gestion.controller.spec.ts` and `auditoria-gestion.service.spec.ts` to include the new `auditoria_padre_id` field. [[1]](diffhunk://#diff-5b7d6bb52f13c07b885be96c10ba315d8b0274d8121173850fa0e460d11e876bR41) [[2]](diffhunk://#diff-b8f615a94108f955dd3fc0cb9114450a03a08a3cad3e74ffaf6e98a585fce1dcR38)

### Test Improvements

* Enhanced the mock for the `Auditoria` model in `auditoria-estado.service.spec.ts` to support the `findByIdAndUpdate` method, improving test coverage for update operations.