### PR TITLE
fix: renombrar miembro auditoria_actividad a auditoria_id en auditoria_padre 

### DIFF
--- a/src/auditoria-padre/auditoria-padre.controller.spec.ts
+++ b/src/auditoria-padre/auditoria-padre.controller.spec.ts
@@ -14,7 +14,7 @@ const mockAuditoriaPadreDTO: AuditoriaPadreDTO = {
   plan_auditoria_id: '67197dda3416d2a85e5d6d8f',
   titulo: 'Auditoría Padre 2024',
   tipo_evaluacion_id: 1,
-  cronograma_actividad: [],
+  cronograma_id: [],
   estado_id: 1,
   vigencia_id: 2024,
   macroproceso_id: 10,

--- a/src/auditoria-padre/auditoria-padre.service.spec.ts
+++ b/src/auditoria-padre/auditoria-padre.service.spec.ts
@@ -11,7 +11,7 @@ const mockAuditoriaPadreDTO: AuditoriaPadreDTO = {
   plan_auditoria_id: '67197dda3416d2a85e5d6d8f',
   titulo: 'Auditoría Padre 2024',
   tipo_evaluacion_id: 1,
-  cronograma_actividad: [],
+  cronograma_id: [],
   estado_id: 1,
   vigencia_id: 2024,
   macroproceso_id: 10,

--- a/src/auditoria-padre/dto/auditoria-padre.dto.ts
+++ b/src/auditoria-padre/dto/auditoria-padre.dto.ts
@@ -11,7 +11,7 @@ export class AuditoriaPadreDTO {
   readonly tipo_evaluacion_id: number;
 
   @ApiProperty()
-  readonly cronograma_actividad: string[] = [];
+  readonly cronograma_id: string[] = [];
 
   @ApiProperty()
   readonly estado_id: number;

--- a/src/auditoria-padre/schemas/auditoria-padre.schema.ts
+++ b/src/auditoria-padre/schemas/auditoria-padre.schema.ts
@@ -14,7 +14,7 @@ export class AuditoriaPadre extends Document {
   tipo_evaluacion_id: number;
 
   @Prop({ type: [{ type: String }], required: false })
-  cronograma_actividad: string[];
+  cronograma_id: string[];
 
   @Prop({ required: false })
   estado_id: number;

--- a/swagger.json
+++ b/swagger.json
@@ -3912,7 +3912,7 @@
           "tipo_evaluacion_id": {
             "type": "number"
           },
-          "cronograma_actividad": {
+          "cronograma_id": {
             "type": "array",
             "items": {
               "type": "string"
@@ -3955,7 +3955,7 @@
           "plan_auditoria_id",
           "titulo",
           "tipo_evaluacion_id",
-          "cronograma_actividad",
+          "cronograma_id",
           "estado_id",
           "vigencia_id",
           "macroproceso_id",


### PR DESCRIPTION
This pull request updates the naming of the `cronograma_actividad` field to `cronograma_id` throughout the `AuditoriaPadre` module to improve consistency and clarity. The changes affect the DTO, schema, service and controller tests, and the Swagger API documentation.

- Answers to udistrital/sisifo_documentacion#557

Field renaming for consistency:

* Renamed the `cronograma_actividad` field to `cronograma_id` in the `AuditoriaPadreDTO` class (`src/auditoria-padre/dto/auditoria-padre.dto.ts`).
* Updated the schema property from `cronograma_actividad` to `cronograma_id` in `AuditoriaPadre` (`src/auditoria-padre/schemas/auditoria-padre.schema.ts`).

Test updates:

* Changed the mock DTOs in both the controller and service tests to use `cronograma_id` instead of `cronograma_actividad` (`src/auditoria-padre/auditoria-padre.controller.spec.ts`, `src/auditoria-padre/auditoria-padre.service.spec.ts`) [[1]](diffhunk://#diff-3e0ef345f03126c7c1e117af5a74b7966345f4d4dd438bc165c182d3e06c4dacL17-R17) [[2]](diffhunk://#diff-f7ba5afe574ebc45431b5bb31baeb680b76c87e87fe417102cdac1ac96899dc9L14-R14).

API documentation update:

* Updated the Swagger JSON to reflect the new field name `cronograma_id` in both the property definition and the required fields list (`swagger.json`) [[1]](diffhunk://#diff-10cfbe600d3f92e886aea1d00df1367f9899549b1a3235442e5191b66ced7e71L3915-R3915) [[2]](diffhunk://#diff-10cfbe600d3f92e886aea1d00df1367f9899549b1a3235442e5191b66ced7e71L3958-R3958).