### PR TITLE
fix: Cambiar cronograma_id a number[] en auditoria-padre 

### DIFF
--- a/src/auditoria-padre/dto/auditoria-padre.dto.ts
+++ b/src/auditoria-padre/dto/auditoria-padre.dto.ts
@@ -11,7 +11,7 @@ export class AuditoriaPadreDTO {
   readonly tipo_evaluacion_id: number;
 
   @ApiProperty()
-  readonly cronograma_id: string[] = [];
+  readonly cronograma_id: number[] = [];
 
   @ApiProperty()
   readonly estado_id: number;

--- a/src/auditoria-padre/schemas/auditoria-padre.schema.ts
+++ b/src/auditoria-padre/schemas/auditoria-padre.schema.ts
@@ -13,8 +13,8 @@ export class AuditoriaPadre extends Document {
   @Prop({ required: false })
   tipo_evaluacion_id: number;
 
-  @Prop({ type: [{ type: String }], required: false })
-  cronograma_id: string[];
+  @Prop({ required: false })
+  cronograma_id: number[];
 
   @Prop({ required: false })
   estado_id: number;


### PR DESCRIPTION
This pull request updates the data types for the `cronograma_id` field in both the DTO and schema for `auditoria-padre` to ensure consistency and correct typing. The field now uses `number[]` instead of `string[]`.

- Answers to udistrital/sisifo_documentacion#557

**Data model and type consistency:**

* Changed the type of `cronograma_id` from `string[]` to `number[]` in the `AuditoriaPadreDTO` class in `auditoria-padre.dto.ts` to reflect the correct data type.
* Updated the `cronograma_id` field in the `AuditoriaPadre` schema in `auditoria-padre.schema.ts` from an array of strings to an array of numbers, removing the explicit type definition for strings.