### PR TITLE
fix: Auditoría especial se generaba con nuevo plan de auditoría inexistente

### DIFF
--- a/src/auditoria/auditoria.service.ts
+++ b/src/auditoria/auditoria.service.ts
@@ -53,7 +53,9 @@ export class AuditoriaService {
     const fecha = new Date();
     const AuditoriaData = {
       ...AuditoriaDto,
-      plan_auditoria_id: new Types.ObjectId(AuditoriaDto.plan_auditoria_id),
+      plan_auditoria_id: AuditoriaDto.plan_auditoria_id
+          ? new Types.ObjectId(AuditoriaDto.plan_auditoria_id as string)
+          : undefined,
       auditoria_padre_id: new Types.ObjectId(AuditoriaDto.auditoria_padre_id),
       activo: true,
       fechaCreacion: fecha,


### PR DESCRIPTION
This pull request makes a small update to the way `plan_auditoria_id` is set in the `AuditoriaService`. The change ensures that an `ObjectId` is only created if `plan_auditoria_id` is present, preventing potential errors when the value is undefined or missing.

Answers:

- udistrital/sisifo_documentacion#738