### PR TITLE
feat: agregar campo de numeración estructurada a hallazgos para registro en aprobación de informe udistrital/sisifo_documentacion#846

### DIFF
--- a/src/hallazgo/dto/hallazgo.dto.ts
+++ b/src/hallazgo/dto/hallazgo.dto.ts
@@ -60,6 +60,12 @@ export class UpdateHallazgoDTO {
 
   @ApiProperty({
     required: false,
+    description: 'Número del hallazgo (jerárquico tema.subtema.hallazgo), sellado al aprobar el informe final',
+  })
+  readonly no_hallazgo?: string;
+
+  @ApiProperty({
+    required: false,
     description: 'Indica si el hallazgo fue rechazado',
   })
   readonly rechazado?: boolean;

--- a/src/hallazgo/dto/hallazgo.dto.ts
+++ b/src/hallazgo/dto/hallazgo.dto.ts
@@ -60,7 +60,8 @@ export class UpdateHallazgoDTO {
 
   @ApiProperty({
     required: false,
-    description: 'Número del hallazgo (jerárquico tema.subtema.hallazgo), sellado al aprobar el informe final',
+    description:
+      'Número del hallazgo (jerárquico tema.subtema.hallazgo), sellado al aprobar el informe final',
   })
   readonly no_hallazgo?: string;
 

--- a/src/hallazgo/schemas/hallazgo.schema.ts
+++ b/src/hallazgo/schemas/hallazgo.schema.ts
@@ -21,6 +21,9 @@ export class Hallazgo extends Document {
   @Prop({ required: true })
   descripcion: string;
 
+  @Prop({ required: false })
+  no_hallazgo: string;
+
   @Prop({ default: false })
   rechazado: boolean;
 

--- a/src/informe/dto/informe.dto.ts
+++ b/src/informe/dto/informe.dto.ts
@@ -43,7 +43,7 @@ export class InformeDTO {
 
   @ApiProperty()
   readonly fecha_aprobacion_informe?: Date;
-  
+
   @ApiProperty()
   readonly ampliacion_revision_auditor_id?: number;
 

--- a/swagger.json
+++ b/swagger.json
@@ -5978,6 +5978,10 @@
             "type": "string",
             "description": "Descripción del hallazgo"
           },
+          "no_hallazgo": {
+            "type": "string",
+            "description": "Número del hallazgo (jerárquico tema.subtema.hallazgo), sellado al aprobar el informe final"
+          },
           "rechazado": {
             "type": "boolean",
             "description": "Indica si el hallazgo fue rechazado"


### PR DESCRIPTION
## Descripción

Se agrega soporte para persistir el número jerárquico de los hallazgos (`{tema}.{subtema}.{hallazgo}`), necesario para el proceso de sellado ejecutado al aprobar el informe final.

Hasta ahora este valor se calculaba únicamente en la interfaz y no se almacenaba en base de datos, lo que ocasionaba cambios en la numeración cuando se eliminaban hallazgos posteriormente.

## Cambios realizados

- Se agregó el campo `no_hallazgo` al schema de hallazgo.
- Se incorporó `no_hallazgo` al `UpdateHallazgoDTO`.
- No fue necesario modificar el servicio de actualización, ya que `findByIdAndUpdate` persiste automáticamente el nuevo campo.

## Notas

- El valor de `no_hallazgo` es asignado desde el MID durante la aprobación del informe final.
- Mientras un hallazgo no haya sido sellado, el campo permanecerá vacío.
- El frontend continúa utilizando la numeración calculada en pantalla como mecanismo de respaldo hasta que el sellado sea ejecutado.